### PR TITLE
doc: Added deprecated tag and updated README with the latest code

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ If you want to prevent user from taking screenshot or recording of your app. You
 
 ```dart
     class _MyHomePageState extends State<MyHomePage> with WidgetsBindingObserver {
-    final _noScreenshot = NoScreenshot();
+    final _noScreenshot = NoScreenshot.instance;
 
   AppLifecycleState? _notification; 
   @override

--- a/lib/no_screenshot.dart
+++ b/lib/no_screenshot.dart
@@ -4,6 +4,9 @@ class NoScreenshot implements NoScreenshotPlatform {
   final _instancePlatform = NoScreenshotPlatform.instance;
   NoScreenshot._();
 
+  @Deprecated("Using this may cause issue\nUse instance directly\ne.g: 'NoScreenshot.instance.screenshotOff()'")
+  NoScreenshot();
+
   /// Made `NoScreenshot` class a singleton
   static NoScreenshot get instance => NoScreenshot._();
 


### PR DESCRIPTION
@fonkamloic 
The issue I found when I was following the documentation on the [pub.dev](https://pub.dev) and also on Github README.
The code was updated but the documentation was still showing the old implementation.
Please do check my PR.
Thanks

## Status

**READY**

## Breaking Changes

NO

## Description

The code was updated but the documentation and the example was not updated.
So I have updated the README file and also added NoScreenshot constructor with a *deprecated* tag on it.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [x] 📝 Documentation
- [ ] 🗑️ Chore
