### PR TITLE
chore: No more read of SharedPreferences on MainThread

### DIFF
--- a/android/src/main/kotlin/com/flutterplaza/no_screenshot/NoScreenshotPlugin.kt
+++ b/android/src/main/kotlin/com/flutterplaza/no_screenshot/NoScreenshotPlugin.kt
@@ -161,7 +161,9 @@ class NoScreenshotPlugin : FlutterPlugin, MethodChannel.MethodCallHandler, Activ
     }
 
     private fun saveScreenshotState(isSecure: Boolean) {
-        preferences.edit().putBoolean(PREF_KEY_SCREENSHOT, isSecure).apply()
+        Executors.newSingleThreadExecutor().execute {
+            preferences.edit().putBoolean(PREF_KEY_SCREENSHOT, isSecure).apply()
+        }
     }
 
     private fun restoreScreenshotState() {


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title of your PR

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

READY

## Breaking Changes

YES

## Description

This should resolve #73 

I used `Executors`'s `newSingleThreadExecutor` to wrap up accesses to `preferences` and then used `runOnUiThread` to post the result.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore
