### PR TITLE
feat: add configurable blur radius and solid color overlay (v0.6.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+## 0.6.0
+
+- feat: added configurable `blurRadius` parameter to `toggleScreenshotWithBlur({double blurRadius})` — defaults to 30.0, customizable per platform by @fonkamloic.
+- feat: added `toggleScreenshotWithColor({int color})` API — solid color overlay for app switcher / recents screen across all platforms by @fonkamloic.
+- feat(android): color overlay via a solid `View` with the specified ARGB color by @fonkamloic.
+- feat(ios): color overlay via `UIView` with the specified background color by @fonkamloic.
+- feat(macos): color overlay via `NSView` with the specified background color by @fonkamloic.
+- feat(linux): color overlay state tracked and persisted (best-effort — compositors control task switcher thumbnails) by @fonkamloic.
+- feat: color, blur, and image overlays are mutually exclusive — activating one deactivates the others, enforced at native level on all platforms by @fonkamloic.
+- feat(example): added Color Overlay section with color picker and toggle button by @fonkamloic.
+- feat(example): added localization strings for color overlay UI by @fonkamloic.
+- test: added method channel, platform interface, and `NoScreenshot` tests for `toggleScreenshotWithBlur` with custom radius and `toggleScreenshotWithColor` by @fonkamloic.
+- docs: updated README, CHANGELOG, roadmap, and example app to reflect configurable blur radius and color overlay support by @fonkamloic.
+
 ## 0.5.0
 
 - feat: added `toggleScreenshotWithBlur()` API — Gaussian blur overlay for app switcher / recents screen (P2) by @fonkamloic.

--- a/example/lib/app_localizations.dart
+++ b/example/lib/app_localizations.dart
@@ -61,6 +61,11 @@ class AppLocalizations {
       'disableRecordingMonitoring': 'Disable Recording Monitoring',
       'stopRecordingListening': 'Stop listening for screen recording',
       'screenRecording': 'Screen recording',
+      'colorOverlaySectionTitle': 'Overlay Color',
+      'colorOverlay': 'Color Overlay',
+      'toggleScreenshotWithColor': 'Toggle Screenshot With Color',
+      'colorOverlaySubtitle':
+          'Show solid color overlay when app is in recents / app switcher',
     },
     'ar': {
       'appTitle': 'مثال بدون لقطة شاشة',
@@ -104,6 +109,11 @@ class AppLocalizations {
       'disableRecordingMonitoring': 'تعطيل مراقبة التسجيل',
       'stopRecordingListening': 'إيقاف الاستماع لتسجيل الشاشة',
       'screenRecording': 'تسجيل الشاشة',
+      'colorOverlaySectionTitle': 'تراكب لوني',
+      'colorOverlay': 'تراكب لوني',
+      'toggleScreenshotWithColor': 'تبديل لقطة الشاشة مع لون',
+      'colorOverlaySubtitle':
+          'عرض تراكب لوني عند ظهور التطبيق في التطبيقات الأخيرة',
     },
   };
 
@@ -178,6 +188,14 @@ class AppLocalizations {
       _localizedValues[locale.languageCode]!['stopRecordingListening']!;
   String get screenRecording =>
       _localizedValues[locale.languageCode]!['screenRecording']!;
+  String get colorOverlaySectionTitle =>
+      _localizedValues[locale.languageCode]!['colorOverlaySectionTitle']!;
+  String get colorOverlay =>
+      _localizedValues[locale.languageCode]!['colorOverlay']!;
+  String get toggleScreenshotWithColor =>
+      _localizedValues[locale.languageCode]!['toggleScreenshotWithColor']!;
+  String get colorOverlaySubtitle =>
+      _localizedValues[locale.languageCode]!['colorOverlaySubtitle']!;
 }
 
 class _AppLocalizationsDelegate

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -63,6 +63,7 @@ class _HomePageState extends State<HomePage> {
   bool _isRecordingMonitoring = false;
   bool _isOverlayImageOn = false;
   bool _isOverlayBlurOn = false;
+  bool _isOverlayColorOn = false;
   ScreenshotSnapshot _latestSnapshot = ScreenshotSnapshot(
     isScreenshotProtectionOn: false,
     wasScreenshotTaken: false,
@@ -136,7 +137,10 @@ class _HomePageState extends State<HomePage> {
     debugPrint('toggleScreenshotWithImage: $result');
     setState(() {
       _isOverlayImageOn = result;
-      if (result) _isOverlayBlurOn = false;
+      if (result) {
+        _isOverlayBlurOn = false;
+        _isOverlayColorOn = false;
+      }
     });
   }
 
@@ -145,7 +149,22 @@ class _HomePageState extends State<HomePage> {
     debugPrint('toggleScreenshotWithBlur: $result');
     setState(() {
       _isOverlayBlurOn = result;
-      if (result) _isOverlayImageOn = false;
+      if (result) {
+        _isOverlayImageOn = false;
+        _isOverlayColorOn = false;
+      }
+    });
+  }
+
+  Future<void> _toggleScreenshotWithColor() async {
+    final result = await _noScreenshot.toggleScreenshotWithColor();
+    debugPrint('toggleScreenshotWithColor: $result');
+    setState(() {
+      _isOverlayColorOn = result;
+      if (result) {
+        _isOverlayImageOn = false;
+        _isOverlayBlurOn = false;
+      }
     });
   }
 
@@ -304,6 +323,23 @@ class _HomePageState extends State<HomePage> {
                 label: l.toggleScreenshotWithBlur,
                 subtitle: l.blurOverlaySubtitle,
                 onPressed: _toggleScreenshotWithBlur,
+              ),
+            ],
+          ),
+          const SizedBox(height: 16),
+          _buildSection(
+            title: l.colorOverlaySectionTitle,
+            subtitle: l.platformSubtitle,
+            children: [
+              _StatusRow(
+                label: l.colorOverlay,
+                isOn: _isOverlayColorOn,
+              ),
+              const SizedBox(height: 12),
+              _FeatureButton(
+                label: l.toggleScreenshotWithColor,
+                subtitle: l.colorOverlaySubtitle,
+                onPressed: _toggleScreenshotWithColor,
               ),
             ],
           ),

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -150,7 +150,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.4.0"
+    version: "0.6.0"
   path:
     dependency: transitive
     description:

--- a/ios/no_screenshot.podspec
+++ b/ios/no_screenshot.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'no_screenshot'
-  s.version          = '0.3.2-beta.3'
+  s.version          = '0.6.0'
   s.summary          = 'Flutter plugin to enable, disable or toggle screenshot support in your application.'
   s.description      = <<-DESC
 A new Flutter plugin project.

--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -2,6 +2,7 @@ const screenShotOnConst = "screenshotOn";
 const screenShotOffConst = "screenshotOff";
 const screenSetImage = "toggleScreenshotWithImage";
 const screenSetBlur = "toggleScreenshotWithBlur";
+const screenSetColor = "toggleScreenshotWithColor";
 const toggleScreenShotConst = "toggleScreenshot";
 const startScreenshotListeningConst = 'startScreenshotListening';
 const stopScreenshotListeningConst = 'stopScreenshotListening';

--- a/lib/no_screenshot.dart
+++ b/lib/no_screenshot.dart
@@ -38,8 +38,13 @@ class NoScreenshot implements NoScreenshotPlatform {
   }
 
   @override
-  Future<bool> toggleScreenshotWithBlur() {
-    return _instancePlatform.toggleScreenshotWithBlur();
+  Future<bool> toggleScreenshotWithBlur({double blurRadius = 30.0}) {
+    return _instancePlatform.toggleScreenshotWithBlur(blurRadius: blurRadius);
+  }
+
+  @override
+  Future<bool> toggleScreenshotWithColor({int color = 0xFF000000}) {
+    return _instancePlatform.toggleScreenshotWithColor(color: color);
   }
 
   /// Return `true` if screenshot capabilities has been

--- a/lib/no_screenshot_method_channel.dart
+++ b/lib/no_screenshot_method_channel.dart
@@ -47,8 +47,16 @@ class MethodChannelNoScreenshot extends NoScreenshotPlatform {
   }
 
   @override
-  Future<bool> toggleScreenshotWithBlur() async {
-    final result = await methodChannel.invokeMethod<bool>(screenSetBlur);
+  Future<bool> toggleScreenshotWithBlur({double blurRadius = 30.0}) async {
+    final result = await methodChannel
+        .invokeMethod<bool>(screenSetBlur, {'radius': blurRadius});
+    return result ?? false;
+  }
+
+  @override
+  Future<bool> toggleScreenshotWithColor({int color = 0xFF000000}) async {
+    final result = await methodChannel
+        .invokeMethod<bool>(screenSetColor, {'color': color});
     return result ?? false;
   }
 

--- a/lib/no_screenshot_platform_interface.dart
+++ b/lib/no_screenshot_platform_interface.dart
@@ -46,9 +46,14 @@ abstract class NoScreenshotPlatform extends PlatformInterface {
         'toggleScreenshotWithImage() has not been implemented.');
   }
 
-  Future<bool> toggleScreenshotWithBlur() {
+  Future<bool> toggleScreenshotWithBlur({double blurRadius = 30.0}) {
     throw UnimplementedError(
         'toggleScreenshotWithBlur() has not been implemented.');
+  }
+
+  Future<bool> toggleScreenshotWithColor({int color = 0xFF000000}) {
+    throw UnimplementedError(
+        'toggleScreenshotWithColor() has not been implemented.');
   }
 
   /// Return `true` if screenshot capabilities has been

--- a/linux/no_screenshot_plugin_private.h
+++ b/linux/no_screenshot_plugin_private.h
@@ -22,6 +22,9 @@ struct _NoScreenshotPlugin {
   gboolean prevent_screenshot;
   gboolean is_image_overlay_mode;
   gboolean is_blur_overlay_mode;
+  gboolean is_color_overlay_mode;
+  gdouble blur_radius;
+  gint color_value;
   gboolean is_listening;
 
   // Event stream

--- a/linux/state_persistence.cc
+++ b/linux/state_persistence.cc
@@ -26,7 +26,10 @@ void state_persistence_free(StatePersistence* self) {
 void state_persistence_save(StatePersistence* self,
                             gboolean prevent_screenshot,
                             gboolean is_image_overlay_mode,
-                            gboolean is_blur_overlay_mode) {
+                            gboolean is_blur_overlay_mode,
+                            gboolean is_color_overlay_mode,
+                            gdouble blur_radius,
+                            gint color_value) {
   g_autofree gchar* dir = g_path_get_dirname(self->file_path);
   g_mkdir_with_parents(dir, 0700);
 
@@ -34,11 +37,17 @@ void state_persistence_save(StatePersistence* self,
       "{\n"
       "  \"prevent_screenshot\": %s,\n"
       "  \"is_image_overlay_mode\": %s,\n"
-      "  \"is_blur_overlay_mode\": %s\n"
+      "  \"is_blur_overlay_mode\": %s,\n"
+      "  \"is_color_overlay_mode\": %s,\n"
+      "  \"blur_radius\": %.1f,\n"
+      "  \"color_value\": %d\n"
       "}\n",
       prevent_screenshot ? "true" : "false",
       is_image_overlay_mode ? "true" : "false",
-      is_blur_overlay_mode ? "true" : "false");
+      is_blur_overlay_mode ? "true" : "false",
+      is_color_overlay_mode ? "true" : "false",
+      blur_radius,
+      color_value);
 
   g_autoptr(GError) error = NULL;
   if (!g_file_set_contents(self->file_path, json, -1, &error)) {
@@ -47,7 +56,7 @@ void state_persistence_save(StatePersistence* self,
 }
 
 PersistedState state_persistence_load(StatePersistence* self) {
-  PersistedState state = {FALSE, FALSE, FALSE};
+  PersistedState state = {FALSE, FALSE, FALSE, FALSE, 30.0, (gint)0xFF000000};
 
   g_autofree gchar* contents = NULL;
   g_autoptr(GError) error = NULL;
@@ -66,6 +75,25 @@ PersistedState state_persistence_load(StatePersistence* self) {
   }
   if (g_strstr_len(contents, -1, "\"is_blur_overlay_mode\": true") != NULL) {
     state.is_blur_overlay_mode = TRUE;
+  }
+  if (g_strstr_len(contents, -1, "\"is_color_overlay_mode\": true") != NULL) {
+    state.is_color_overlay_mode = TRUE;
+  }
+
+  // Extract blur_radius (simple parse after key)
+  const gchar* radius_key = "\"blur_radius\": ";
+  const gchar* radius_pos = g_strstr_len(contents, -1, radius_key);
+  if (radius_pos != NULL) {
+    state.blur_radius = g_ascii_strtod(radius_pos + strlen(radius_key), NULL);
+    if (state.blur_radius <= 0) state.blur_radius = 30.0;
+  }
+
+  // Extract color_value (simple parse after key)
+  const gchar* color_key = "\"color_value\": ";
+  const gchar* color_pos = g_strstr_len(contents, -1, color_key);
+  if (color_pos != NULL) {
+    state.color_value = (gint)g_ascii_strtoll(color_pos + strlen(color_key),
+                                              NULL, 10);
   }
 
   return state;

--- a/linux/state_persistence.h
+++ b/linux/state_persistence.h
@@ -9,6 +9,9 @@ typedef struct {
   gboolean prevent_screenshot;
   gboolean is_image_overlay_mode;
   gboolean is_blur_overlay_mode;
+  gboolean is_color_overlay_mode;
+  gdouble blur_radius;
+  gint color_value;
 } PersistedState;
 
 typedef struct _StatePersistence StatePersistence;
@@ -19,7 +22,10 @@ void state_persistence_free(StatePersistence* self);
 void state_persistence_save(StatePersistence* self,
                             gboolean prevent_screenshot,
                             gboolean is_image_overlay_mode,
-                            gboolean is_blur_overlay_mode);
+                            gboolean is_blur_overlay_mode,
+                            gboolean is_color_overlay_mode,
+                            gdouble blur_radius,
+                            gint color_value);
 
 PersistedState state_persistence_load(StatePersistence* self);
 

--- a/macos/no_screenshot.podspec
+++ b/macos/no_screenshot.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'no_screenshot'
-  s.version          = '0.3.2-beta.3'
+  s.version          = '0.6.0'
   s.summary          = 'Flutter plugin to enable, disable or toggle screenshot support in your application.'
   s.description      = <<-DESC
 A new Flutter plugin project.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,8 +1,8 @@
 name: no_screenshot
 description: Flutter plugin to enable, disable, toggle or stream screenshot and screen recording activities in your application.
-version: 0.5.0
+version: 0.6.0
 homepage: https://flutterplaza.com
-repository: https://github.com/FlutterPlaza/no_screenshot/releases/tag/v0.5.0
+repository: https://github.com/FlutterPlaza/no_screenshot/releases/tag/v0.6.0
 
 environment:
   sdk: '>=3.0.0 <4.0.0'

--- a/test/no_screenshot_method_channel_test.dart
+++ b/test/no_screenshot_method_channel_test.dart
@@ -103,12 +103,28 @@ void main() {
       TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
           .setMockMethodCallHandler(channel, (MethodCall methodCall) async {
         if (methodCall.method == screenSetBlur) {
+          expect(methodCall.arguments, {'radius': 30.0});
           return expected;
         }
         return null;
       });
 
       final result = await platform.toggleScreenshotWithBlur();
+      expect(result, expected);
+    });
+
+    test('toggleScreenshotWithBlur with custom radius', () async {
+      const bool expected = true;
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, (MethodCall methodCall) async {
+        if (methodCall.method == screenSetBlur) {
+          expect(methodCall.arguments, {'radius': 50.0});
+          return expected;
+        }
+        return null;
+      });
+
+      final result = await platform.toggleScreenshotWithBlur(blurRadius: 50.0);
       expect(result, expected);
     });
 
@@ -120,6 +136,48 @@ void main() {
       });
 
       final result = await platform.toggleScreenshotWithBlur();
+      expect(result, false);
+    });
+
+    test('toggleScreenshotWithColor', () async {
+      const bool expected = true;
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, (MethodCall methodCall) async {
+        if (methodCall.method == screenSetColor) {
+          expect(methodCall.arguments, {'color': 0xFF000000});
+          return expected;
+        }
+        return null;
+      });
+
+      final result = await platform.toggleScreenshotWithColor();
+      expect(result, expected);
+    });
+
+    test('toggleScreenshotWithColor with custom color', () async {
+      const bool expected = true;
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, (MethodCall methodCall) async {
+        if (methodCall.method == screenSetColor) {
+          expect(methodCall.arguments, {'color': 0xFFFF0000});
+          return expected;
+        }
+        return null;
+      });
+
+      final result =
+          await platform.toggleScreenshotWithColor(color: 0xFFFF0000);
+      expect(result, expected);
+    });
+
+    test('toggleScreenshotWithColor returns false when channel returns null',
+        () async {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, (MethodCall methodCall) async {
+        return null;
+      });
+
+      final result = await platform.toggleScreenshotWithColor();
       expect(result, false);
     });
 

--- a/test/no_screenshot_platform_interface_test.dart
+++ b/test/no_screenshot_platform_interface_test.dart
@@ -39,7 +39,12 @@ class MockNoScreenshotPlatform extends NoScreenshotPlatform {
   }
 
   @override
-  Future<bool> toggleScreenshotWithBlur() async {
+  Future<bool> toggleScreenshotWithBlur({double blurRadius = 30.0}) async {
+    return true;
+  }
+
+  @override
+  Future<bool> toggleScreenshotWithColor({int color = 0xFF000000}) async {
     return true;
   }
 
@@ -117,6 +122,18 @@ void main() {
         () {
       final basePlatform = BaseNoScreenshotPlatform();
       expect(() => basePlatform.toggleScreenshotWithBlur(),
+          throwsUnimplementedError);
+    });
+
+    test('toggleScreenshotWithColor should return true when called', () async {
+      expect(await platform.toggleScreenshotWithColor(), isTrue);
+    });
+
+    test(
+        'base NoScreenshotPlatform.toggleScreenshotWithColor() throws UnimplementedError',
+        () {
+      final basePlatform = BaseNoScreenshotPlatform();
+      expect(() => basePlatform.toggleScreenshotWithColor(),
           throwsUnimplementedError);
     });
 

--- a/test/no_screenshot_test.dart
+++ b/test/no_screenshot_test.dart
@@ -26,7 +26,12 @@ class MockNoScreenshotPlatform
   }
 
   @override
-  Future<bool> toggleScreenshotWithBlur() async {
+  Future<bool> toggleScreenshotWithBlur({double blurRadius = 30.0}) async {
+    return Future.value(true);
+  }
+
+  @override
+  Future<bool> toggleScreenshotWithColor({int color = 0xFF000000}) async {
     return Future.value(true);
   }
 
@@ -112,6 +117,23 @@ void main() {
 
   test('toggleScreenshotWithBlur', () async {
     expect(await NoScreenshot.instance.toggleScreenshotWithBlur(), true);
+  });
+
+  test('toggleScreenshotWithBlur with custom radius', () async {
+    expect(
+        await NoScreenshot.instance.toggleScreenshotWithBlur(blurRadius: 50.0),
+        true);
+  });
+
+  test('toggleScreenshotWithColor', () async {
+    expect(await NoScreenshot.instance.toggleScreenshotWithColor(), true);
+  });
+
+  test('toggleScreenshotWithColor with custom color', () async {
+    expect(
+        await NoScreenshot.instance
+            .toggleScreenshotWithColor(color: 0xFFFF0000),
+        true);
   });
 
   test('NoScreenshot equality operator', () {


### PR DESCRIPTION
Add configurable blurRadius parameter to toggleScreenshotWithBlur() and new toggleScreenshotWithColor() API for solid color overlays in app switcher across all platforms. Color, blur, and image overlays are mutually exclusive.

<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title of your PR

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY/IN DEVELOPMENT/HOLD**

## Breaking Changes

YES | NO

## Description

<!--- Describe your changes in detail -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
