### PR TITLE
New assets names

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,8 +250,8 @@ Future<void> toggleOverlay() async {
 
 **Setup:** Place your overlay image in the platform-specific asset locations:
 
-- **Android:** `android/app/src/main/res/drawable/image.png`
-- **iOS:** Add an image named `image` to your asset catalog (`Runner/Assets.xcassets/image.imageset/`)
+- **Android:** `android/app/src/main/res/drawable/no_screenshot_image.png`
+- **iOS:** Add an image named `NoScreenshotImage` to your asset catalog (`Runner/Assets.xcassets/NoScreenshotImage.imageset/`)
 - **macOS:** Add an image named `image` to your asset catalog (`Runner/Assets.xcassets/image.imageset/`)
 - **Linux:** Best-effort — the state is tracked but compositors control task switcher thumbnails
 

--- a/android/src/main/kotlin/com/flutterplaza/no_screenshot/NoScreenshotPlugin.kt
+++ b/android/src/main/kotlin/com/flutterplaza/no_screenshot/NoScreenshotPlugin.kt
@@ -271,7 +271,7 @@ class NoScreenshotPlugin : FlutterPlugin, MethodChannel.MethodCallHandler, Activ
 
     private fun showImageOverlay(activity: Activity) {
         if (overlayImageView != null) return
-        val resId = activity.resources.getIdentifier("image", "drawable", activity.packageName)
+        val resId = activity.resources.getIdentifier("no_screenshot_image", "drawable", activity.packageName)
         if (resId == 0) return
         activity.runOnUiThread {
             val imageView = ImageView(activity).apply {

--- a/ios/no_screenshot/Sources/no_screenshot/IOSNoScreenshotPlugin.swift
+++ b/ios/no_screenshot/Sources/no_screenshot/IOSNoScreenshotPlugin.swift
@@ -138,7 +138,7 @@ public class IOSNoScreenshotPlugin: NSObject, FlutterPlugin, FlutterStreamHandle
             // visible in the app switcher (otherwise the secure text field
             // would show a blank screen).
             disablePreventScreenshot()
-            enableImageScreen(named: "image")
+            enableImageScreen(named: "NoScreenshotImage")
         } else if isBlurOverlayModeEnabled {
             disablePreventScreenshot()
             enableBlurScreen(radius: blurRadius)


### PR DESCRIPTION
## Status

**READY**

## Breaking Changes

YES

## Description

I updated the naming of files taken by native methods to NoScreenshotImage for iOS and no_screenshot_image for Android.
By default, Apple ImagesSet uses capital letters for image set names. When building and updating dependencies, a simple "image" with a lowercase letter can be overwritten and lost at the iOS level. This change is also not reflected in the version control system.
Furthermore, the name "image" may not be obvious to new team members.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [X] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [X] 📝 Documentation
- [ ] 🗑️ Chore
