### PR TITLE
fix(macos): replace CGWindowListCreateImage with cacheDisplay for macOS 26 SDK

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -155,7 +155,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.0.0"
+    version: "1.1.0"
   path:
     dependency: transitive
     description:

--- a/ios/no_screenshot/Sources/no_screenshot/IOSNoScreenshotPlugin.swift
+++ b/ios/no_screenshot/Sources/no_screenshot/IOSNoScreenshotPlugin.swift
@@ -330,6 +330,10 @@ public class IOSNoScreenshotPlugin: NSObject, FlutterPlugin, FlutterStreamHandle
         return isBlurOverlayModeEnabled
     }
 
+    // CIContext allocates GPU resources; share one instance instead of
+    // creating a new context on every blur-overlay call.
+    private static let ciContext = CIContext(options: nil)
+
     private func enableBlurScreen(radius: Double) {
         guard let window = attachedWindow else { return }
 
@@ -343,12 +347,13 @@ public class IOSNoScreenshotPlugin: NSObject, FlutterPlugin, FlutterStreamHandle
         guard let ciImage = CIImage(image: snapshot),
               let filter = CIFilter(name: "CIGaussianBlur") else { return }
 
-        filter.setValue(ciImage, forKey: kCIInputImageKey)
+        // Clamp before blurring so edges don't fade to transparent,
+        // then crop back to the original extent.
+        filter.setValue(ciImage.clampedToExtent(), forKey: kCIInputImageKey)
         filter.setValue(radius, forKey: kCIInputRadiusKey)
 
-        let context = CIContext(options: nil)
         guard let output = filter.outputImage,
-              let cgImage = context.createCGImage(output, from: ciImage.extent) else { return }
+              let cgImage = IOSNoScreenshotPlugin.ciContext.createCGImage(output, from: ciImage.extent) else { return }
 
         let imageView = UIImageView(frame: window.bounds)
         imageView.image = UIImage(cgImage: cgImage)

--- a/ios/no_screenshot/Sources/no_screenshot/IOSNoScreenshotPlugin.swift
+++ b/ios/no_screenshot/Sources/no_screenshot/IOSNoScreenshotPlugin.swift
@@ -332,7 +332,7 @@ public class IOSNoScreenshotPlugin: NSObject, FlutterPlugin, FlutterStreamHandle
 
     // CIContext allocates GPU resources; share one instance instead of
     // creating a new context on every blur-overlay call.
-    private static let ciContext = CIContext(options: nil)
+    private static let ciContext = CIContext()
 
     private func enableBlurScreen(radius: Double) {
         guard let window = attachedWindow else { return }
@@ -352,7 +352,7 @@ public class IOSNoScreenshotPlugin: NSObject, FlutterPlugin, FlutterStreamHandle
         filter.setValue(ciImage.clampedToExtent(), forKey: kCIInputImageKey)
         filter.setValue(radius, forKey: kCIInputRadiusKey)
 
-        guard let output = filter.outputImage,
+        guard let output = filter.outputImage?.cropped(to: ciImage.extent),
               let cgImage = IOSNoScreenshotPlugin.ciContext.createCGImage(output, from: ciImage.extent) else { return }
 
         let imageView = UIImageView(frame: window.bounds)

--- a/lib/no_screenshot.dart
+++ b/lib/no_screenshot.dart
@@ -102,9 +102,10 @@ class NoScreenshot implements NoScreenshotPlatform {
 
   /// Toggles the blur overlay shown in the app switcher.
   ///
-  /// On macOS, Flutter content is GPU-rendered and cannot be snapshotted
-  /// without a Screen Recording permission, so the system blur material is
-  /// used instead and [blurRadius] has no effect there.
+  /// On macOS, Flutter draws into a `CAMetalLayer` whose GPU content
+  /// AppKit's snapshot API cannot capture, so the system blur material
+  /// is used instead and [blurRadius] has no effect there. (Granting
+  /// Screen Recording permission would not change this.)
   @override
   Future<bool> toggleScreenshotWithBlur({double blurRadius = 30.0}) {
     return _instancePlatform.toggleScreenshotWithBlur(blurRadius: blurRadius);

--- a/lib/no_screenshot.dart
+++ b/lib/no_screenshot.dart
@@ -100,6 +100,11 @@ class NoScreenshot implements NoScreenshotPlatform {
     return _instancePlatform.toggleScreenshotWithImage();
   }
 
+  /// Toggles the blur overlay shown in the app switcher.
+  ///
+  /// On macOS, Flutter content is GPU-rendered and cannot be snapshotted
+  /// without a Screen Recording permission, so the system blur material is
+  /// used instead and [blurRadius] has no effect there.
   @override
   Future<bool> toggleScreenshotWithBlur({double blurRadius = 30.0}) {
     return _instancePlatform.toggleScreenshotWithBlur(blurRadius: blurRadius);
@@ -117,6 +122,9 @@ class NoScreenshot implements NoScreenshotPlatform {
   }
 
   /// Always enables blur overlay mode (idempotent — safe to call repeatedly).
+  ///
+  /// On macOS the system blur material is used and [blurRadius] has no
+  /// effect — see [toggleScreenshotWithBlur].
   @override
   Future<bool> screenshotWithBlur({double blurRadius = 30.0}) {
     return _instancePlatform.screenshotWithBlur(blurRadius: blurRadius);

--- a/macos/no_screenshot/Sources/no_screenshot/MacOSNoScreenshotPlugin.swift
+++ b/macos/no_screenshot/Sources/no_screenshot/MacOSNoScreenshotPlugin.swift
@@ -1,5 +1,6 @@
 import Cocoa
 import FlutterMacOS
+import QuartzCore
 
 public class MacOSNoScreenshotPlugin: NSObject, FlutterPlugin, FlutterStreamHandler {
     private static var methodChannel: FlutterMethodChannel? = nil
@@ -285,6 +286,16 @@ public class MacOSNoScreenshotPlugin: NSObject, FlutterPlugin, FlutterStreamHand
         return isBlurOverlayModeEnabled
     }
 
+    // CIContext allocates GPU resources; share one instance instead of
+    // creating a new context on every blur-overlay call.
+    private static let ciContext = CIContext()
+
+    private static func containsMetalLayer(_ layer: CALayer?) -> Bool {
+        guard let layer = layer else { return false }
+        if layer is CAMetalLayer { return true }
+        return layer.sublayers?.contains { containsMetalLayer($0) } ?? false
+    }
+
     private func showBlurOverlay(radius: Double) {
         DispatchQueue.main.async { [weak self] in
             guard let self = self, self.blurOverlayView == nil else { return }
@@ -292,11 +303,16 @@ public class MacOSNoScreenshotPlugin: NSObject, FlutterPlugin, FlutterStreamHand
                   let contentView = window.contentView else { return }
 
             // Capture the window's view hierarchy via cacheDisplay and apply CIGaussianBlur.
-            // This mirrors the iOS implementation (UIView.drawHierarchy) and avoids
-            // CGWindowListCreateImage, which is unavailable in the macOS 26 (Tahoe) SDK.
-            // Apple's replacement, ScreenCaptureKit, would require Screen Recording
-            // permission — unnecessary for a self-snapshot like this.
-            if let bitmapRep = contentView.bitmapImageRepForCachingDisplay(in: contentView.bounds) {
+            // This avoids CGWindowListCreateImage, which is unavailable in the macOS 26
+            // (Tahoe) SDK; Apple's replacement, ScreenCaptureKit, would require Screen
+            // Recording permission — unnecessary for a self-snapshot like this.
+            //
+            // cacheDisplay uses AppKit's software path and cannot capture GPU-backed
+            // CAMetalLayer content (it comes out black). Flutter renders into a
+            // CAMetalLayer, so when one is present skip straight to the
+            // NSVisualEffectView fallback instead of blurring a black snapshot.
+            if !MacOSNoScreenshotPlugin.containsMetalLayer(contentView.layer),
+               let bitmapRep = contentView.bitmapImageRepForCachingDisplay(in: contentView.bounds) {
                 contentView.cacheDisplay(in: contentView.bounds, to: bitmapRep)
                 if let cgImage = bitmapRep.cgImage,
                    let filter = CIFilter(name: "CIGaussianBlur") {
@@ -307,8 +323,7 @@ public class MacOSNoScreenshotPlugin: NSObject, FlutterPlugin, FlutterStreamHand
                     filter.setValue(radius, forKey: kCIInputRadiusKey)
 
                     if let outputImage = filter.outputImage?.cropped(to: ciImage.extent) {
-                        let context = CIContext()
-                        if let blurredCGImage = context.createCGImage(outputImage, from: ciImage.extent) {
+                        if let blurredCGImage = MacOSNoScreenshotPlugin.ciContext.createCGImage(outputImage, from: ciImage.extent) {
                             let nsImage = NSImage(cgImage: blurredCGImage, size: contentView.bounds.size)
                             let imageView = NSImageView(frame: contentView.bounds)
                             imageView.image = nsImage

--- a/macos/no_screenshot/Sources/no_screenshot/MacOSNoScreenshotPlugin.swift
+++ b/macos/no_screenshot/Sources/no_screenshot/MacOSNoScreenshotPlugin.swift
@@ -291,34 +291,39 @@ public class MacOSNoScreenshotPlugin: NSObject, FlutterPlugin, FlutterStreamHand
             guard let window = NSApplication.shared.windows.first,
                   let contentView = window.contentView else { return }
 
-            // Capture window content and apply CIGaussianBlur
-            let windowID = CGWindowID(window.windowNumber)
-            if let cgImage = CGWindowListCreateImage(
-                .null, .optionIncludingWindow, windowID,
-                [.boundsIgnoreFraming, .bestResolution]
-            ) {
-                let ciImage = CIImage(cgImage: cgImage)
-                let filter = CIFilter(name: "CIGaussianBlur")!
-                filter.setValue(ciImage, forKey: kCIInputImageKey)
-                filter.setValue(radius, forKey: kCIInputRadiusKey)
+            // Capture the window's view hierarchy via cacheDisplay and apply CIGaussianBlur.
+            // This mirrors the iOS implementation (UIView.drawHierarchy) and avoids
+            // CGWindowListCreateImage, which is unavailable in the macOS 26 (Tahoe) SDK.
+            // Apple's replacement, ScreenCaptureKit, would require Screen Recording
+            // permission — unnecessary for a self-snapshot like this.
+            if let bitmapRep = contentView.bitmapImageRepForCachingDisplay(in: contentView.bounds) {
+                contentView.cacheDisplay(in: contentView.bounds, to: bitmapRep)
+                if let cgImage = bitmapRep.cgImage,
+                   let filter = CIFilter(name: "CIGaussianBlur") {
+                    let ciImage = CIImage(cgImage: cgImage)
+                    // Clamp before blurring so edges don't fade to transparent,
+                    // then crop back to the original extent.
+                    filter.setValue(ciImage.clampedToExtent(), forKey: kCIInputImageKey)
+                    filter.setValue(radius, forKey: kCIInputRadiusKey)
 
-                if let outputImage = filter.outputImage {
-                    let context = CIContext()
-                    let extent = ciImage.extent
-                    if let blurredCGImage = context.createCGImage(outputImage, from: extent) {
-                        let nsImage = NSImage(cgImage: blurredCGImage, size: contentView.bounds.size)
-                        let imageView = NSImageView(frame: contentView.bounds)
-                        imageView.image = nsImage
-                        imageView.imageScaling = .scaleProportionallyUpOrDown
-                        imageView.autoresizingMask = [.width, .height]
-                        contentView.addSubview(imageView, positioned: .above, relativeTo: contentView.subviews.last)
-                        self.blurOverlayView = imageView
-                        return
+                    if let outputImage = filter.outputImage?.cropped(to: ciImage.extent) {
+                        let context = CIContext()
+                        if let blurredCGImage = context.createCGImage(outputImage, from: ciImage.extent) {
+                            let nsImage = NSImage(cgImage: blurredCGImage, size: contentView.bounds.size)
+                            let imageView = NSImageView(frame: contentView.bounds)
+                            imageView.image = nsImage
+                            imageView.imageScaling = .scaleProportionallyUpOrDown
+                            imageView.autoresizingMask = [.width, .height]
+                            contentView.addSubview(imageView, positioned: .above, relativeTo: contentView.subviews.last)
+                            self.blurOverlayView = imageView
+                            return
+                        }
                     }
                 }
             }
 
-            // Fallback: NSVisualEffectView
+            // Fallback: NSVisualEffectView (used when cacheDisplay or CIFilter fails,
+            // e.g. zero-sized view or unsupported GPU-backed content).
             let blurView = NSVisualEffectView(frame: contentView.bounds)
             blurView.material = .hudWindow
             blurView.blendingMode = .behindWindow


### PR DESCRIPTION
## Summary

Supersedes #102 — credit to @paulanatoleclaudot-betclic for the original fix.

`CGWindowListCreateImage` is marked unavailable in the macOS 26 (Tahoe) SDK, so the blur-overlay snapshot no longer compiles. Apple's replacement, ScreenCaptureKit, would require Screen Recording permission just to snapshot the app's own window — rejected.

## Effective behavior on macOS

Flutter draws into a `CAMetalLayer`, whose GPU content AppKit's `cacheDisplay` cannot capture (it comes out black). The code detects this and uses the `NSVisualEffectView` system blur — so **for Flutter apps, the blur overlay is now always the system blur material and the custom `blurRadius` has no effect on macOS** (documented on the Dart API). Content is still fully obscured in Mission Control / the app switcher; this fidelity trade-off is forced by the SDK removal.

The `cacheDisplay` + `CIGaussianBlur` path is kept (not dead-coded out) for hosts where Flutter falls back to software rendering (no-Metal VMs/CI), where the snapshot is capturable.

## Changes on top of #102

- Detect `CAMetalLayer` in the view tree and fall through to `NSVisualEffectView` instead of blurring a black snapshot
- Clamp-before-blur + crop on both macOS and iOS (fixes overlay edges fading to transparent)
- Shared static `CIContext` on both platforms (was allocated per call)
- `CIFilter(name:)!` force-unwrap removed
- Dart docs for `toggleScreenshotWithBlur`/`screenshotWithBlur` note the macOS limitation
- `example/pubspec.lock` refresh (1.0.0 → 1.1.0) is intentional — stale lock, pubspec is already 1.1.0

## Validation

`flutter build macos --debug` succeeds; `flutter analyze` and all 52 tests pass.