### PR TITLE
fix(android): migrate to AGP built-in Kotlin support

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -49,6 +49,10 @@ android {
     }
 }
 
+// The kotlin {} extension exists on both paths: registered by KGP on
+// AGP < 9 and by AGP's built-in Kotlin on 9+. The compilerOptions DSL
+// requires KGP >= 1.9; fine here since the plugin's minimum Flutter
+// (3.38) ships KGP 2.x.
 kotlin {
     compilerOptions {
         jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_1_8

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,7 +22,14 @@ allprojects {
 }
 
 apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
+
+// AGP 9+ ships built-in Kotlin support and no longer allows applying the
+// Kotlin Gradle Plugin; only apply it on older AGP versions. See
+// https://docs.flutter.dev/release/breaking-changes/migrate-to-built-in-kotlin/for-plugin-authors
+def agpMajor = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0] as int
+if (agpMajor < 9) {
+    apply plugin: 'kotlin-android'
+}
 
 android {
     namespace "com.flutterplaza.no_screenshot"
@@ -33,15 +40,17 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
-    kotlinOptions {
-        jvmTarget = '1.8'
-    }
-
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
     }
 
     defaultConfig {
         minSdkVersion 16
+    }
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_1_8
     }
 }


### PR DESCRIPTION
## Summary

Fixes #104.

Starting with AGP 9.0, support for applying the Kotlin Gradle Plugin has been removed, so this plugin currently breaks app builds on AGP 9+ (Flutter is only allowing it temporarily — see [flutter/flutter#181383](https://github.com/flutter/flutter/issues/181383)).

## Changes

Follows the official [migration guide for plugin authors](https://docs.flutter.dev/release/breaking-changes/migrate-to-built-in-kotlin/for-plugin-authors), using the backwards-compatible variant since this plugin supports Flutter ≥ 3.38 (the unconditional form requires bumping the minimum to Flutter 3.44):

- Apply `kotlin-android` only when AGP < 9 (AGP 9+ has built-in Kotlin)
- Replace the `kotlinOptions { jvmTarget }` block with the top-level `kotlin { compilerOptions { jvmTarget } }` DSL, which works on both paths

## Validation

`flutter build apk --debug` on the example app succeeds (exercises the AGP < 9 path; the AGP 9 path is the guide's verbatim pattern).