### PR TITLE
fix(ios): skip secure-field prevention when iOS app runs on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- fix(ios): iOS builds running on Apple-silicon Macs ("Designed for iPhone/iPad") no longer show a permanently black/white window at launch ([#107](https://github.com/FlutterPlaza/no_screenshot/issues/107)). Screenshot prevention is not supported by this technique on a macOS host, so `screenshotOff()` now returns `false` there; app-switcher overlays and screenshot/recording detection are unaffected.
+
 ## 1.1.0
 
 - breaking: renamed overlay image assets on all platforms to avoid generic-name collisions ([#99](https://github.com/FlutterPlaza/no_screenshot/pull/99)) by @yar-tsar.

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -155,7 +155,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.0.0"
+    version: "1.1.0"
   path:
     dependency: transitive
     description:

--- a/ios/no_screenshot/Sources/no_screenshot/IOSNoScreenshotPlugin.swift
+++ b/ios/no_screenshot/Sources/no_screenshot/IOSNoScreenshotPlugin.swift
@@ -66,12 +66,9 @@ public class IOSNoScreenshotPlugin: NSObject, FlutterPlugin, FlutterStreamHandle
 
     // MARK: - Inline Screenshot Prevention (replaces ScreenProtectorKit)
 
-    // True when an iOS build runs on macOS ("Designed for iPhone/iPad" on
-    // Apple silicon). The secure-text-field capture protection below relies
-    // on reparenting the window's CALayer under a UITextField layer, which
-    // macOS's UIKit host does not support — it permanently blanks the whole
-    // window (black/white screen at launch). Prevention is skipped there;
-    // overlays and detection still work.
+    // The secure-field layer reparenting permanently blanks the window on
+    // macOS's UIKit host ("Designed for iPhone/iPad" on Apple silicon), so
+    // prevention is skipped there; overlays and detection still work.
     private static let isiOSAppOnMac: Bool = {
         if #available(iOS 14.0, *) {
             return ProcessInfo.processInfo.isiOSAppOnMac
@@ -229,10 +226,16 @@ public class IOSNoScreenshotPlugin: NSObject, FlutterPlugin, FlutterStreamHandle
     public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
         switch call.method {
         case "screenshotOff":
-            shotOff()
-            // On a macOS host the secure-field protection cannot engage
-            // (see isiOSAppOnMac); report failure per the Dart API contract.
-            result(!IOSNoScreenshotPlugin.isiOSAppOnMac)
+            // On a macOS host the secure-field protection cannot engage (see
+            // isiOSAppOnMac). Skip shotOff() entirely — it would persist and
+            // broadcast is_screenshot_on: true for protection that isn't
+            // active — and report failure per the Dart API contract.
+            if IOSNoScreenshotPlugin.isiOSAppOnMac {
+                result(false)
+            } else {
+                shotOff()
+                result(true)
+            }
         case "screenshotOn":
             shotOn()
             result(true)
@@ -248,8 +251,14 @@ public class IOSNoScreenshotPlugin: NSObject, FlutterPlugin, FlutterStreamHandle
             let isActive = toggleScreenshotWithColor(color: color)
             result(isActive)
         case "toggleScreenshot":
-            IOSNoScreenshotPlugin.preventScreenShot ? shotOn() : shotOff()
-            result(true)
+            // Same macOS-host guard as screenshotOff: toggling would call
+            // shotOff() and poison the persisted/stream state.
+            if IOSNoScreenshotPlugin.isiOSAppOnMac {
+                result(false)
+            } else {
+                IOSNoScreenshotPlugin.preventScreenShot ? shotOn() : shotOff()
+                result(true)
+            }
         case "screenshotWithImage":
             enableImageOverlay()
             result(true)

--- a/ios/no_screenshot/Sources/no_screenshot/IOSNoScreenshotPlugin.swift
+++ b/ios/no_screenshot/Sources/no_screenshot/IOSNoScreenshotPlugin.swift
@@ -72,12 +72,12 @@ public class IOSNoScreenshotPlugin: NSObject, FlutterPlugin, FlutterStreamHandle
     // macOS's UIKit host does not support — it permanently blanks the whole
     // window (black/white screen at launch). Prevention is skipped there;
     // overlays and detection still work.
-    private static var isiOSAppOnMac: Bool {
+    private static let isiOSAppOnMac: Bool = {
         if #available(iOS 14.0, *) {
             return ProcessInfo.processInfo.isiOSAppOnMac
         }
         return false
-    }
+    }()
 
     private func configurePreventionScreenshot(window: UIWindow) {
         guard !IOSNoScreenshotPlugin.isiOSAppOnMac else { return }
@@ -230,7 +230,9 @@ public class IOSNoScreenshotPlugin: NSObject, FlutterPlugin, FlutterStreamHandle
         switch call.method {
         case "screenshotOff":
             shotOff()
-            result(true)
+            // On a macOS host the secure-field protection cannot engage
+            // (see isiOSAppOnMac); report failure per the Dart API contract.
+            result(!IOSNoScreenshotPlugin.isiOSAppOnMac)
         case "screenshotOn":
             shotOn()
             result(true)

--- a/ios/no_screenshot/Sources/no_screenshot/IOSNoScreenshotPlugin.swift
+++ b/ios/no_screenshot/Sources/no_screenshot/IOSNoScreenshotPlugin.swift
@@ -10,7 +10,18 @@ public class IOSNoScreenshotPlugin: NSObject, FlutterPlugin, FlutterStreamHandle
     private weak var attachedWindow: UIWindow? = nil
     private static var methodChannel: FlutterMethodChannel? = nil
     private static var eventChannel: FlutterEventChannel? = nil
-    private static var preventScreenShot: Bool = false
+    // On a macOS host prevention can never engage (see isiOSAppOnMac), so
+    // clamp the flag to false at the source: every writer — including the
+    // overlay modes, which also enable prevention — would otherwise persist
+    // and broadcast is_screenshot_on: true for protection that isn't active.
+    // Assigning inside didSet does not re-trigger the observer.
+    private static var preventScreenShot: Bool = false {
+        didSet {
+            if isiOSAppOnMac && preventScreenShot {
+                preventScreenShot = false
+            }
+        }
+    }
     private var eventSink: FlutterEventSink? = nil
     private var lastSharedPreferencesState: String = ""
     private var hasSharedPreferencesChanged: Bool = false

--- a/ios/no_screenshot/Sources/no_screenshot/IOSNoScreenshotPlugin.swift
+++ b/ios/no_screenshot/Sources/no_screenshot/IOSNoScreenshotPlugin.swift
@@ -66,7 +66,21 @@ public class IOSNoScreenshotPlugin: NSObject, FlutterPlugin, FlutterStreamHandle
 
     // MARK: - Inline Screenshot Prevention (replaces ScreenProtectorKit)
 
+    // True when an iOS build runs on macOS ("Designed for iPhone/iPad" on
+    // Apple silicon). The secure-text-field capture protection below relies
+    // on reparenting the window's CALayer under a UITextField layer, which
+    // macOS's UIKit host does not support — it permanently blanks the whole
+    // window (black/white screen at launch). Prevention is skipped there;
+    // overlays and detection still work.
+    private static var isiOSAppOnMac: Bool {
+        if #available(iOS 14.0, *) {
+            return ProcessInfo.processInfo.isiOSAppOnMac
+        }
+        return false
+    }
+
     private func configurePreventionScreenshot(window: UIWindow) {
+        guard !IOSNoScreenshotPlugin.isiOSAppOnMac else { return }
         guard let rootLayer = window.layer.superlayer else { return }
         guard screenPrevent.layer.superlayer == nil else { return }
 

--- a/ios/no_screenshot/Sources/no_screenshot/IOSNoScreenshotPlugin.swift
+++ b/ios/no_screenshot/Sources/no_screenshot/IOSNoScreenshotPlugin.swift
@@ -14,7 +14,12 @@ public class IOSNoScreenshotPlugin: NSObject, FlutterPlugin, FlutterStreamHandle
     // clamp the flag to false at the source: every writer — including the
     // overlay modes, which also enable prevention — would otherwise persist
     // and broadcast is_screenshot_on: true for protection that isn't active.
-    // Assigning inside didSet does not re-trigger the observer.
+    // The flag deliberately tracks the ACTUAL protection state, not the
+    // requested one: on a Mac an overlay mode can be active while prevention
+    // is off, and is_screenshot_on reports prevention, not overlay
+    // visibility. toggleScreenshot is short-circuited on macOS hosts, so the
+    // toggle direction never depends on this clamp. Assigning inside didSet
+    // does not re-trigger the observer.
     private static var preventScreenShot: Bool = false {
         didSet {
             if isiOSAppOnMac && preventScreenShot {

--- a/lib/no_screenshot.dart
+++ b/lib/no_screenshot.dart
@@ -81,6 +81,10 @@ class NoScreenshot implements NoScreenshotPlatform {
   /// successfully disabled or is currently disabled and `false` otherwise.
   /// throw `UnmimplementedError` if not implement
   ///
+  /// Always returns `false` when an iOS build runs on a Mac
+  /// ("Designed for iPhone/iPad" on Apple silicon) — screenshot
+  /// prevention is not supported there, though overlays and
+  /// screenshot/recording detection still work.
   @override
   Future<bool> screenshotOff() {
     return _instancePlatform.screenshotOff();

--- a/lib/no_screenshot.dart
+++ b/lib/no_screenshot.dart
@@ -94,6 +94,8 @@ class NoScreenshot implements NoScreenshotPlatform {
   /// successfully enabled or is currently enabled and `false` otherwise.
   /// throw `UnmimplementedError` if not implement
   ///
+  /// Always returns `true` when an iOS build runs on a Mac —
+  /// screenshots are permitted there by default.
   @override
   Future<bool> screenshotOn() {
     return _instancePlatform.screenshotOn();

--- a/lib/no_screenshot.dart
+++ b/lib/no_screenshot.dart
@@ -137,6 +137,9 @@ class NoScreenshot implements NoScreenshotPlatform {
   /// to toggle failed.
   /// throw `UnmimplementedError` if not implement
   ///
+  /// Always returns `false` when an iOS build runs on a Mac
+  /// ("Designed for iPhone/iPad" on Apple silicon) — screenshot
+  /// prevention is not supported there; see [screenshotOff].
   @override
   Future<bool> toggleScreenshot() {
     return _instancePlatform.toggleScreenshot();

--- a/lib/no_screenshot_platform_interface.dart
+++ b/lib/no_screenshot_platform_interface.dart
@@ -39,6 +39,9 @@ abstract class NoScreenshotPlatform extends PlatformInterface {
   /// Return `true` if screenshot capabilities has been
   /// successfully enabled or is currently enabled and `false` otherwise.
   /// throw `UnmimplementedError` if not implement
+  ///
+  /// Always returns `true` when an iOS build runs on a Mac —
+  /// screenshots are permitted there by default.
   Future<bool> screenshotOn() {
     throw UnimplementedError('screenshotOn() has not been implemented.');
   }

--- a/lib/no_screenshot_platform_interface.dart
+++ b/lib/no_screenshot_platform_interface.dart
@@ -27,6 +27,11 @@ abstract class NoScreenshotPlatform extends PlatformInterface {
   /// Return `true` if screenshot capabilities has been
   /// successfully disabled or is currently disabled and `false` otherwise.
   /// throw `UnmimplementedError` if not implement
+  ///
+  /// Always returns `false` when an iOS build runs on a Mac
+  /// ("Designed for iPhone/iPad" on Apple silicon) — screenshot
+  /// prevention is not supported there, though overlays and
+  /// screenshot/recording detection still work.
   Future<bool> screenshotOff() {
     throw UnimplementedError('screenshotOff() has not been implemented.');
   }
@@ -78,6 +83,10 @@ abstract class NoScreenshotPlatform extends PlatformInterface {
   /// successfully toggle from it previous state and `false` if the attempt
   /// to toggle failed.
   /// throw `UnmimplementedError` if not implement
+  ///
+  /// Always returns `false` when an iOS build runs on a Mac
+  /// ("Designed for iPhone/iPad" on Apple silicon) — screenshot
+  /// prevention is not supported there; see [screenshotOff].
   Future<bool> toggleScreenshot() {
     throw UnimplementedError('toggleScreenshot() has not been implemented.');
   }

--- a/test/no_screenshot_method_channel_test.dart
+++ b/test/no_screenshot_method_channel_test.dart
@@ -49,6 +49,22 @@ void main() {
       expect(result, expected);
     });
 
+    test(
+      'screenshotOff surfaces platform failure (e.g. iOS app on Mac)',
+      () async {
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(channel, (MethodCall methodCall) async {
+              if (methodCall.method == screenShotOffConst) {
+                return false;
+              }
+              return null;
+            });
+
+        final result = await platform.screenshotOff();
+        expect(result, isFalse);
+      },
+    );
+
     test('toggleScreenshot', () async {
       const bool expected = true;
       TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger

--- a/test/no_screenshot_method_channel_test.dart
+++ b/test/no_screenshot_method_channel_test.dart
@@ -79,6 +79,22 @@ void main() {
       expect(result, expected);
     });
 
+    test(
+      'toggleScreenshot surfaces platform failure (e.g. iOS app on Mac)',
+      () async {
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(channel, (MethodCall methodCall) async {
+              if (methodCall.method == toggleScreenShotConst) {
+                return false;
+              }
+              return null;
+            });
+
+        final result = await platform.toggleScreenshot();
+        expect(result, isFalse);
+      },
+    );
+
     test('startScreenshotListening', () async {
       TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
           .setMockMethodCallHandler(channel, (MethodCall methodCall) async {


### PR DESCRIPTION
## Summary

Fixes #107 — iOS builds installed on Apple-silicon Macs ("Designed for iPhone/iPad") showed a fully black/white window at launch and never became usable.

## Cause

`configurePreventionScreenshot` reparents the window's `CALayer` under a secure `UITextField`'s layer — and it runs at plugin registration (via `attachWindowIfNeeded`) even when prevention is off. macOS's UIKit host doesn't support this layer arrangement, so the whole window renders blank permanently.

## Fix

- Detect `ProcessInfo.processInfo.isiOSAppOnMac` (iOS 14+, `#available`-gated, cached in a `static let`) and skip the layer reparenting on Macs.
- `screenshotOff()` and `toggleScreenshot()` return `false` on a macOS host **without touching state** — per the documented Dart contract, `true` means prevention actually engaged.
- A `didSet` observer clamps `preventScreenShot` to `false` on macOS hosts at the single source of truth, so no writer (including the overlay modes, which also enable prevention) can persist or broadcast `is_screenshot_on: true` for protection that isn't active.

## Design notes (re: review)

- The clamp deliberately tracks the **actual** protection state, not the requested one: on a Mac an overlay mode can be active while prevention is off, and `is_screenshot_on` reports prevention — not overlay visibility. Overlay activation still returns its mode state truthfully (overlays genuinely work on Mac).
- `toggleScreenshot` is short-circuited on macOS hosts, so the toggle direction never depends on the clamped flag.
- `screenshotOn()` keeps returning `true` on Mac (screenshots are permitted there by default) — documented on the wrapper and the platform interface; its passthrough is covered by the existing `screenshotOn` test.
- `example/pubspec.lock` (1.0.0 → 1.1.0) is tool-generated on any `pub get` since the pubspec is already at 1.1.0; #109 carries the identical refresh, so whichever merges first absorbs it.

## Trade-off

Screenshot prevention is simply not achievable with the secure-field technique on macOS — an unusable app is strictly worse. App-switcher overlays (image/blur/color) and screenshot/recording detection are unaffected. Documented in CHANGELOG and on the Dart APIs (`screenshotOff`, `screenshotOn`, `toggleScreenshot`, wrapper + platform interface).

## Validation

`swiftc -parse` clean, `flutter analyze` clean, full test suite passes (127 tests, including new false-path tests for `screenshotOff` and `toggleScreenshot`). A full iOS build wasn't possible on this machine (iOS platform not downloaded in Xcode).