### PR TITLE
chore(deps): bump GitHub Actions to pinned versions

### DIFF
--- a/.github/workflows/claude-code-review.yaml
+++ b/.github/workflows/claude-code-review.yaml
@@ -18,7 +18,7 @@ jobs:
           fetch-depth: 1
 
       - name: Run Claude Code Review
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@v1.0.183
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -53,7 +53,7 @@ jobs:
           fi
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage/lcov.info

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -32,4 +32,4 @@ jobs:
       id-token: write
     # Uses the reusable publish workflow provided by dart-lang/setup-dart.
     # This handles OIDC token exchange and runs `dart pub publish --force`.
-    uses: dart-lang/setup-dart/.github/workflows/publish.yml@v1
+    uses: dart-lang/setup-dart/.github/workflows/publish.yml@v1.7.2


### PR DESCRIPTION
Consolidates the three open dependabot PRs into a single manual bump:

- `anthropics/claude-code-action` from `v1` to `v1.0.183` (closes #122)
- `dart-lang/setup-dart/.github/workflows/publish.yml` from `v1` to `v1.7.2` (closes #121)
- `codecov/codecov-action` from `v5` to `v7` (closes #106)