### PR TITLE
fix(android): stop applying KGP from the plugin build script (Built-in Kotlin)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- fix(android): the plugin's build script no longer applies the Kotlin Gradle Plugin (KGP), not even conditionally — the Flutter tool detects KGP usage by statically scanning plugin build scripts, so the previous AGP-version conditional still triggered the "Your app uses the following plugins that apply Kotlin Gradle Plugin (KGP)" warning ([#120](https://github.com/FlutterPlaza/no_screenshot/issues/120)). Kotlin is now provided by the Flutter tool itself: AGP's built-in Kotlin on AGP 9+, and an auto-applied KGP on older AGP versions. **The minimum Flutter version is now 3.44** (was 3.38), the first release whose Gradle tooling auto-applies KGP for plugins.
+
 ## 1.3.0-beta.1
 
 > **Beta — please test before the stable 1.3.0.** This release changes how prevention state is

--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ To migrate an existing project from CocoaPods to SPM, see [Flutter's SPM migrati
 
 > **Testing 1.3.0-beta?** This release adds `overlayOff()` and changes prevention to a two-claim model: `screenshotOff()`/`screenshotOn()` and the overlay modes each own a prevention claim, and protection stays on while either is held. Apps that use only one of the two APIs behave exactly as before; mixed sequences now resolve fail-secure (see the [CHANGELOG](CHANGELOG.md) for the exact deltas). Please verify your protection flows and report issues.
 >
+> The upcoming release also completes the [Built-in Kotlin migration](https://docs.flutter.dev/release/breaking-changes/migrate-to-built-in-kotlin/for-plugin-authors) — the plugin no longer applies the Kotlin Gradle Plugin, which removes Flutter's "plugins that apply KGP" build warning ([#120](https://github.com/FlutterPlaza/no_screenshot/issues/120)). This raises the minimum Flutter version to **3.44**.
+>
 > **Upgrading from 0.10.x?** This release includes Android 15 screen recording detection support — no code changes required on your side. See the [CHANGELOG](CHANGELOG.md) for details.
 >
 > **Upgrading from 0.9.x?** This release includes two important iOS changes — no code changes required on your side:

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -10,6 +10,9 @@ buildscript {
 
     dependencies {
         classpath 'com.android.tools.build:gradle:8.6.0'
+        // KGP stays on the buildscript classpath even though this script never
+        // applies it: on AGP < 9 the Flutter tool applies KGP to this project
+        // and resolves it from here.
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
@@ -23,13 +26,12 @@ allprojects {
 
 apply plugin: 'com.android.library'
 
-// AGP 9+ ships built-in Kotlin support and no longer allows applying the
-// Kotlin Gradle Plugin; only apply it on older AGP versions. See
+// This script must not apply the Kotlin Gradle Plugin, not even conditionally:
+// the Flutter tool statically scans plugin build scripts for KGP usage (a
+// runtime conditional still matches and triggers the "plugins that apply KGP"
+// warning, see #120) and provides Kotlin itself — built-in Kotlin on AGP 9+,
+// auto-applied KGP on older AGP (requires Flutter >= 3.44). See
 // https://docs.flutter.dev/release/breaking-changes/migrate-to-built-in-kotlin/for-plugin-authors
-def agpMajor = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0] as int
-if (agpMajor < 9) {
-    apply plugin: 'kotlin-android'
-}
 
 android {
     namespace "com.flutterplaza.no_screenshot"
@@ -50,10 +52,8 @@ android {
     }
 }
 
-// The kotlin {} extension exists on both paths: registered by KGP on
-// AGP < 9 and by AGP's built-in Kotlin on 9+. The compilerOptions DSL
-// requires KGP >= 1.9; fine here since the plugin's minimum Flutter
-// (3.38) ships KGP 2.x.
+// The kotlin {} extension exists on both paths: registered by the KGP the
+// Flutter tool applies on AGP < 9, and by AGP's built-in Kotlin on 9+.
 kotlin {
     compilerOptions {
         jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_1_8

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,8 +12,8 @@ topics:
   - app-switcher
 
 environment:
-  sdk: '>=3.10.0 <4.0.0'
-  flutter: ">=3.38.0"
+  sdk: '>=3.12.0 <4.0.0'
+  flutter: ">=3.44.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
Fixes #120 — the "plugins that apply Kotlin Gradle Plugin (KGP)" warning that still appears on 1.2.0.

## Why the warning persisted

1.2.0 (#110) applied KGP *conditionally* (`if (agpMajor < 9) apply plugin: 'kotlin-android'`). But the Flutter tool doesn't inspect runtime plugin state — it **statically regex-scans** each plugin's `build.gradle` for KGP declarations ([`FlutterPluginUtils.kt`](https://github.com/flutter/flutter/blob/stable/packages/flutter_tools/gradle/src/main/kotlin/FlutterPluginUtils.kt), deliberate due to [Gradle lifecycle-ordering issues](https://github.com/gradle/gradle/issues/36953) with conditional application). So the conditional `apply plugin: 'kotlin-android'` line matches the scan and triggers the warning even when it never executes.

## The fix (per the official plugin migration guide + how flutter/packages first-party plugins do it)

- Remove the KGP application from `android/build.gradle` entirely. Since Flutter 3.44, the Flutter tool provides Kotlin itself: AGP's built-in Kotlin on AGP 9+, and an auto-applied KGP on older AGP — resolved from the `kotlin-gradle-plugin` classpath entry the script still declares (same layout as `url_launcher_android`).
- The existing `kotlin { compilerOptions { jvmTarget } }` block keeps working on both paths.
- **Raises minimum Flutter to 3.44 / Dart 3.12** in `pubspec.yaml`. This is required, not optional: I verified against the local 3.41.2 SDK sources that pre-3.44 Gradle tooling has no KGP auto-apply at all, so on older Flutter the plugin's Kotlin would simply never compile. Same constraint bump `flutter/packages` plugins made for this migration.
- CHANGELOG (`## Unreleased`) + README note.

## Verification

- The `Build Android` CI job builds the example APK on stable (≥ 3.44), exercising the tool-applied KGP path end to end.
- Local verification isn't possible on my 3.41.2 toolchain — which is itself the demonstration of why the constraint bump is needed (`pub get` now correctly refuses).

## Notes for release

- Should land in the upcoming stable (1.3.0/2.0.0) so #120 is fixed there; the raised Flutter minimum is already in the `Unreleased` changelog section.
- Example app intentionally untouched: the app-side migration needs AGP 9 / Flutter 3.47 and doesn't affect the plugin-side warning consumers see.