### PR TITLE
chore(release): 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
-## Unreleased
+## 2.0.0
 
+> **Breaking release.** Two things to check before upgrading:
+>
+> 1. **Prevention is now tracked as two separate claims** (released for testing in 1.3.0-beta.1, see below). Apps that use only `screenshotOff()`/`screenshotOn()` or only the overlay-mode APIs behave exactly as before; apps that *mix* the two now resolve fail-secure — protection stays on until both claims are released (`overlayOff()` + `screenshotOn()`).
+> 2. **The minimum Flutter version is now 3.44** (Dart 3.12).
+
+- All changes from 1.3.0-beta.1 (see below): the new `overlayOff()` method, the two-claim prevention model, and the `SecureWidget`/`applyOverlayMode` overlay-teardown fixes.
 - fix(android): the plugin's build script no longer applies the Kotlin Gradle Plugin (KGP), not even conditionally — the Flutter tool detects KGP usage by statically scanning plugin build scripts, so the previous AGP-version conditional still triggered the "Your app uses the following plugins that apply Kotlin Gradle Plugin (KGP)" warning ([#120](https://github.com/FlutterPlaza/no_screenshot/issues/120)). Kotlin is now provided by the Flutter tool itself: AGP's built-in Kotlin on AGP 9+, and an auto-applied KGP on older AGP versions. **The minimum Flutter version is now 3.44** (was 3.38), the first release whose Gradle tooling auto-applies KGP for plugins.
 
 ## 1.3.0-beta.1

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Add `no_screenshot` to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  no_screenshot: ^1.3.0-beta.1
+  no_screenshot: ^2.0.0
 ```
 
 Then run:
@@ -80,9 +80,9 @@ flutter create my_app
 
 To migrate an existing project from CocoaPods to SPM, see [Flutter's SPM migration guide](https://docs.flutter.dev/packages-and-plugins/swift-package-manager/for-app-developers#how-to-turn-on-swift-package-manager).
 
-> **Testing 1.3.0-beta?** This release adds `overlayOff()` and changes prevention to a two-claim model: `screenshotOff()`/`screenshotOn()` and the overlay modes each own a prevention claim, and protection stays on while either is held. Apps that use only one of the two APIs behave exactly as before; mixed sequences now resolve fail-secure (see the [CHANGELOG](CHANGELOG.md) for the exact deltas). Please verify your protection flows and report issues.
+> **Upgrading to 2.0.0?** This release adds `overlayOff()` and changes prevention to a two-claim model: `screenshotOff()`/`screenshotOn()` and the overlay modes each own a prevention claim, and protection stays on while either is held. Apps that use only one of the two APIs behave exactly as before; mixed sequences now resolve fail-secure (see the [CHANGELOG](CHANGELOG.md) for the exact deltas).
 >
-> The upcoming release also completes the [Built-in Kotlin migration](https://docs.flutter.dev/release/breaking-changes/migrate-to-built-in-kotlin/for-plugin-authors) — the plugin no longer applies the Kotlin Gradle Plugin, which removes Flutter's "plugins that apply KGP" build warning ([#120](https://github.com/FlutterPlaza/no_screenshot/issues/120)). This raises the minimum Flutter version to **3.44**.
+> 2.0.0 also completes the [Built-in Kotlin migration](https://docs.flutter.dev/release/breaking-changes/migrate-to-built-in-kotlin/for-plugin-authors) — the plugin no longer applies the Kotlin Gradle Plugin, which removes Flutter's "plugins that apply KGP" build warning ([#120](https://github.com/FlutterPlaza/no_screenshot/issues/120)). This raises the minimum Flutter version to **3.44** (Dart 3.12).
 >
 > **Upgrading from 0.10.x?** This release includes Android 15 screen recording detection support — no code changes required on your side. See the [CHANGELOG](CHANGELOG.md) for details.
 >

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -155,7 +155,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.3.0-beta.1"
+    version: "2.0.0"
   path:
     dependency: transitive
     description:
@@ -250,5 +250,5 @@ packages:
     source: hosted
     version: "1.1.1"
 sdks:
-  dart: ">=3.10.0 <4.0.0"
-  flutter: ">=3.38.0"
+  dart: ">=3.12.0 <4.0.0"
+  flutter: ">=3.44.0"

--- a/ios/no_screenshot.podspec
+++ b/ios/no_screenshot.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'no_screenshot'
-  s.version          = '1.3.0-beta.1'
+  s.version          = '2.0.0'
   s.summary          = 'Flutter plugin to enable, disable or toggle screenshot support in your application.'
   s.description      = <<-DESC
 A new Flutter plugin project.

--- a/macos/no_screenshot.podspec
+++ b/macos/no_screenshot.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'no_screenshot'
-  s.version          = '1.3.0-beta.1'
+  s.version          = '2.0.0'
   s.summary          = 'Flutter plugin to enable, disable or toggle screenshot support in your application.'
   s.description      = <<-DESC
 A new Flutter plugin project.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: no_screenshot
 description: Flutter plugin to prevent screenshots, detect screen recording, and show blur/color/image overlays in the app switcher on Android, iOS, macOS, Linux, Windows, and Web.
-version: 1.3.0-beta.1
+version: 2.0.0
 homepage: https://flutterplaza.com
 repository: https://github.com/FlutterPlaza/no_screenshot
 


### PR DESCRIPTION
Stable release bump: 1.3.0-beta.1 → **2.0.0**.

2.0.0 rather than 1.3.0 per the #117 review recommendation: the two-claim prevention model is a breaking behavior change for apps that mix the plain and overlay APIs, and #124 raises the minimum Flutter to 3.44 (Dart 3.12).

Changes:
- `pubspec.yaml`, both podspecs: version → 2.0.0
- `CHANGELOG.md`: new 2.0.0 section (breaking callout + Built-in Kotlin entry, rolls up 1.3.0-beta.1)
- `README.md`: install snippet → `^2.0.0`, beta callout rewritten as stable upgrade notes
- `example/pubspec.lock`: refresh stale version + SDK bounds (local Flutter < 3.44 can't run `pub get`; CI verifies resolution)

After merge: tag `v2.0.0` on the merge commit → OIDC publish workflow.