### PR TITLE
fix(windows): apply display affinity to the top-level window, not the child view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- fix(windows): screenshot prevention now applies `SetWindowDisplayAffinity` to the **top-level** window instead of the child Flutter view ([#119](https://github.com/FlutterPlaza/no_screenshot/issues/119)). Display affinity is a top-level-window property, and the Flutter runner reparents the view via `SetParent`, so the previous code silently protected nothing — `screenshotOff()` reported success while window content stayed fully capturable. The plugin now resolves the root ancestor on every call and re-asserts persisted prevention once the view is attached to its real top-level window, covering both the standard runner and multi-window embeddings (e.g. `desktop_multi_window`). Notes: with prevention active, the entire top-level window (title bar included) is now hidden from capture, matching native behavior; the plugin now effectively owns the top-level window's display affinity, so don't combine it with other plugins that set it (e.g. `window_manager`'s prevent-screen-capture); engines without a view (headless add-to-app) remain a no-op.
+
 ## 2.0.0
 
 > **Breaking release.** Two things to check before upgrading:

--- a/windows/no_screenshot_plugin.cpp
+++ b/windows/no_screenshot_plugin.cpp
@@ -3,6 +3,7 @@
 #include "screenshot_prevention.h"
 
 #include <chrono>
+#include <optional>
 #include <sstream>
 
 namespace no_screenshot {
@@ -79,6 +80,29 @@ NoScreenshotPlugin::NoScreenshotPlugin(
         UpdateSharedState("", last_timestamp_ms_, last_source_app_);
       });
 
+  // Display affinity must live on the top-level window, but the standard
+  // runner registers plugins BEFORE it reparents the Flutter view into that
+  // window (SetChildContent -> SetParent), so the persisted-state restore
+  // below cannot reach it yet. This delegate receives the top-level window's
+  // HWND once messages flow; if prevention is engaged but applied elsewhere
+  // (or nowhere effective), migrate it there (#119).
+  window_proc_delegate_id_ = registrar_->RegisterTopLevelWindowProcDelegate(
+      [this](HWND hwnd, UINT message, WPARAM wparam,
+             LPARAM lparam) -> std::optional<LRESULT> {
+        // Adopt only the window that actually hosts our view — an embedder
+        // may forward several top-level windows' messages into one engine,
+        // and migrating to a foreign window would thrash the affinity.
+        if (prevent_screenshot_ && applied_hwnd_ != hwnd &&
+            hwnd == GetFlutterWindowHandle()) {
+          if (applied_hwnd_ != nullptr && ::IsWindow(applied_hwnd_)) {
+            PreventionDeactivate(applied_hwnd_);
+          }
+          PreventionActivate(hwnd);
+          applied_hwnd_ = hwnd;
+        }
+        return std::nullopt;
+      });
+
   // Load persisted state
   PersistedState state = persistence_.Load();
   is_image_overlay_mode_ = state.is_image_overlay_mode;
@@ -106,6 +130,9 @@ NoScreenshotPlugin::NoScreenshotPlugin(
 }
 
 NoScreenshotPlugin::~NoScreenshotPlugin() {
+  if (window_proc_delegate_id_ != -1 && registrar_ != nullptr) {
+    registrar_->UnregisterTopLevelWindowProcDelegate(window_proc_delegate_id_);
+  }
   StopEventStream();
   if (detection_) detection_->Stop();
   if (recording_detection_) recording_detection_->Stop();
@@ -115,7 +142,16 @@ NoScreenshotPlugin::~NoScreenshotPlugin() {
 HWND NoScreenshotPlugin::GetFlutterWindowHandle() {
   if (registrar_ == nullptr) return nullptr;
   auto* view = registrar_->GetView();
-  return view ? view->GetNativeWindow() : nullptr;
+  HWND view_hwnd = view ? view->GetNativeWindow() : nullptr;
+  if (view_hwnd == nullptr) return nullptr;
+  // SetWindowDisplayAffinity only takes effect on top-level windows, and the
+  // Flutter view is a child window that the runner reparents via SetParent —
+  // affinity set on the view itself silently protects nothing (#119). Resolve
+  // the root ancestor on every call, never cached: the parent chain changes
+  // when the runner attaches the view after plugin registration. For a view
+  // that is itself top-level, GA_ROOT returns the view unchanged.
+  HWND root = ::GetAncestor(view_hwnd, GA_ROOT);
+  return root ? root : view_hwnd;
 }
 
 // ---------------------------------------------------------------------------
@@ -136,11 +172,29 @@ void NoScreenshotPlugin::ApplyEffectivePrevention() {
   const bool effective = independent_prevention_ || OverlayClaim();
   prevent_screenshot_ = effective;
   HWND hwnd = GetFlutterWindowHandle();
-  if (hwnd == nullptr) return;
+  if (hwnd == nullptr) {
+    // View not resolvable (headless engine or teardown). Releasing
+    // prevention must still clear a previously protected window; an active
+    // claim keeps that window protected (fail-secure).
+    if (!effective && applied_hwnd_ != nullptr && ::IsWindow(applied_hwnd_)) {
+      PreventionDeactivate(applied_hwnd_);
+      applied_hwnd_ = nullptr;
+    }
+    return;
+  }
+  // If a previous apply targeted a different window (the view resolved
+  // before the runner reparented it), clear that one first so no window is
+  // left holding a stale affinity.
+  if (applied_hwnd_ != nullptr && applied_hwnd_ != hwnd &&
+      ::IsWindow(applied_hwnd_)) {
+    PreventionDeactivate(applied_hwnd_);
+  }
   if (effective) {
     PreventionActivate(hwnd);
+    applied_hwnd_ = hwnd;
   } else {
     PreventionDeactivate(hwnd);
+    applied_hwnd_ = nullptr;
   }
 }
 

--- a/windows/no_screenshot_plugin.h
+++ b/windows/no_screenshot_plugin.h
@@ -77,6 +77,12 @@ class NoScreenshotPlugin : public flutter::Plugin {
   bool has_pending_event_ = false;
   UINT_PTR stream_timer_id_ = 0;
 
+  // Window the display affinity is currently applied to. Tracked so
+  // deactivation always targets the window that was actually protected,
+  // even if the view has been reparented since (#119).
+  HWND applied_hwnd_ = nullptr;
+  int window_proc_delegate_id_ = -1;
+
   // P8 metadata
   int64_t last_timestamp_ms_ = 0;
   std::string last_source_app_;


### PR DESCRIPTION
Fixes #119.

## Problem

`SetWindowDisplayAffinity` is a top-level-window property (MSDN: it fails on non-top-level windows), but the plugin applied it to `registrar->GetView()->GetNativeWindow()` — the child `FLUTTERVIEW` window, which the runner reparents into the top-level window via `SetParent`. Both failed affinity calls were silently swallowed, so `screenshotOff()` reported success while window content stayed fully capturable. Windows prevention has been ineffective since it shipped.

There is also a second bug the issue's proposed one-liner doesn't cover: the standard runner calls `RegisterPlugins` **before** `SetChildContent`/`SetParent`, so the constructor-time restore of persisted prevention state runs while the view is still under `HWND_MESSAGE` — `GetAncestor(GA_ROOT)` at that moment cannot reach the real top-level window.

## Fix

- `GetFlutterWindowHandle()` resolves `GetAncestor(view_hwnd, GA_ROOT)` on **every call** (never cached; the parent chain changes when the runner attaches the view). This is the canonical idiom used by `window_manager`, `dwm.flutter`, and `desktop_multi_window` itself.
- New `applied_hwnd_` tracker: deactivation always clears the window that was actually protected, and releasing prevention clears it even if the view is no longer resolvable — no window is ever left with a stuck affinity.
- A `RegisterTopLevelWindowProcDelegate` callback (per-instance, unregistered in the destructor) migrates the affinity to the true top-level HWND on the first forwarded message, fixing the cold-launch persisted-state restore. It only adopts the window that hosts our view, so embedders forwarding multiple top-level windows into one engine can't cause thrashing.

## Verification

- Claims validated against the Flutter engine source (`flutter_window.cc` creates the view as `WS_CHILD` under `HWND_MESSAGE`; template runner ordering; `WindowProcDelegateManager` passes the top-level HWND through) and MSDN.
- `desktop_multi_window` secondary windows register plugins after `SetParent`, so per-call `GA_ROOT` resolution covers the reporter's scenario directly.
- CI Windows example build is the compile gate (this code cannot be built on the maintainer's macOS host).

Behavior notes (also in CHANGELOG): with prevention active the entire top-level window (title bar included) is hidden from capture; the plugin now effectively owns the top-level window's display affinity, so it shouldn't be combined with other plugins that set it; headless/add-to-app engines without a view remain a no-op.