### PR TITLE
chore(release): 2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 2.0.1
 
 - fix(windows): screenshot prevention now applies `SetWindowDisplayAffinity` to the **top-level** window instead of the child Flutter view ([#119](https://github.com/FlutterPlaza/no_screenshot/issues/119)). Display affinity is a top-level-window property, and the Flutter runner reparents the view via `SetParent`, so the previous code silently protected nothing — `screenshotOff()` reported success while window content stayed fully capturable. The plugin now resolves the root ancestor on every call and re-asserts persisted prevention once the view is attached to its real top-level window, covering both the standard runner and multi-window embeddings (e.g. `desktop_multi_window`). Notes: with prevention active, the entire top-level window (title bar included) is now hidden from capture, matching native behavior; the plugin now effectively owns the top-level window's display affinity, so don't combine it with other plugins that set it (e.g. `window_manager`'s prevent-screen-capture); engines without a view (headless add-to-app) remain a no-op.
 

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -155,7 +155,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.0.0"
+    version: "2.0.1"
   path:
     dependency: transitive
     description:

--- a/ios/no_screenshot.podspec
+++ b/ios/no_screenshot.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'no_screenshot'
-  s.version          = '2.0.0'
+  s.version          = '2.0.1'
   s.summary          = 'Flutter plugin to enable, disable or toggle screenshot support in your application.'
   s.description      = <<-DESC
 A new Flutter plugin project.

--- a/macos/no_screenshot.podspec
+++ b/macos/no_screenshot.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'no_screenshot'
-  s.version          = '2.0.0'
+  s.version          = '2.0.1'
   s.summary          = 'Flutter plugin to enable, disable or toggle screenshot support in your application.'
   s.description      = <<-DESC
 A new Flutter plugin project.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: no_screenshot
 description: Flutter plugin to prevent screenshots, detect screen recording, and show blur/color/image overlays in the app switcher on Android, iOS, macOS, Linux, Windows, and Web.
-version: 2.0.0
+version: 2.0.1
 homepage: https://flutterplaza.com
 repository: https://github.com/FlutterPlaza/no_screenshot
 


### PR DESCRIPTION
Patch release: **2.0.1** — ships the Windows display-affinity fix (#119, PR #126).

Changes:
- `pubspec.yaml`, both podspecs, `example/pubspec.lock`: version → 2.0.1
- `CHANGELOG.md`: `## Unreleased` → `## 2.0.1`

After merge: tag `v2.0.1` → OIDC publish workflow.