### PR TITLE
ci: add Windows native tests, AGP 9 coverage, and action bumps

### DIFF
--- a/.github/workflows/android-early-warning.yaml
+++ b/.github/workflows/android-early-warning.yaml
@@ -1,0 +1,38 @@
+# Early-warning signal for the AGP 9+ built-in Kotlin path (#129): builds
+# the example against Flutter beta with android.builtInKotlin=true, so
+# upcoming Flutter/AGP changes that would break the plugin's no-KGP build
+# script (#120) surface before they reach stable. Failures here are
+# informational — they do not block PRs.
+
+name: Android Early Warning
+
+on:
+  schedule:
+    # Weekly, Monday 06:00 UTC.
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+jobs:
+  build-android-beta:
+    name: Build Android (Flutter beta, built-in Kotlin)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: "21"
+
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: beta
+
+      - name: Switch the example to AGP's built-in Kotlin
+        run: |
+          sed -i 's/^android.builtInKotlin=false$/android.builtInKotlin=true/' example/android/gradle.properties
+          grep -q '^android.builtInKotlin=true$' example/android/gradle.properties
+
+      - name: Build Android example (built-in Kotlin)
+        run: flutter build apk --debug
+        working-directory: example

--- a/.github/workflows/claude-code-review.yaml
+++ b/.github/workflows/claude-code-review.yaml
@@ -6,6 +6,9 @@ on:
 
 jobs:
   claude-review:
+    # Dependabot-triggered runs don't receive repository secrets, so the
+    # review can't authenticate there — and version bumps don't need it.
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -18,7 +21,7 @@ jobs:
           fetch-depth: 1
 
       - name: Run Claude Code Review
-        uses: anthropics/claude-code-action@v1.0.183
+        uses: anthropics/claude-code-action@v1.0.191
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |

--- a/.github/workflows/claude-code-review.yaml
+++ b/.github/workflows/claude-code-review.yaml
@@ -6,9 +6,6 @@ on:
 
 jobs:
   claude-review:
-    # Dependabot-triggered runs don't receive repository secrets, so the
-    # review can't authenticate there — and version bumps don't need it.
-    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -21,7 +18,7 @@ jobs:
           fetch-depth: 1
 
       - name: Run Claude Code Review
-        uses: anthropics/claude-code-action@v1.0.191
+        uses: anthropics/claude-code-action@v1.0.183
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -56,22 +56,68 @@ jobs:
         run: flutter build windows --debug
         working-directory: example
 
+      # Native googletest coverage for the display-affinity logic (#128).
+      # The example build already compiles the test target (it is part of
+      # ALL); this explicit build is a cheap no-op guard so the test binary's
+      # existence never silently depends on the INSTALL target's behavior.
+      - name: Build native unit tests
+        run: cmake --build build/windows/x64 --config Debug --target unit_tests
+        working-directory: example
+
+      - name: Run native unit tests
+        shell: pwsh
+        working-directory: example
+        run: |
+          $exe = Get-ChildItem -Recurse -Path build/windows/x64 -Filter no_screenshot_test.exe |
+            Where-Object { $_.FullName -match '[\\/]Debug[\\/]' } | Select-Object -First 1
+          if (-not $exe) { Write-Error "no_screenshot_test.exe not found"; exit 1 }
+          & $exe.FullName
+          exit $LASTEXITCODE
+
   build-android:
     name: Build Android
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: "17"
+          java-version: "21"
 
       - uses: subosito/flutter-action@v2
         with:
           channel: stable
 
       - name: Build Android example
+        run: flutter build apk --debug
+        working-directory: example
+
+  # The example defaults to android.builtInKotlin=false (Flutter's current
+  # AGP 9 default, flutter/flutter#183910), so the job above exercises the
+  # legacy auto-applied-KGP path. This lane flips the flag to cover the
+  # AGP 9+ built-in Kotlin path the plugin relies on (#120, #129).
+  build-android-builtin-kotlin:
+    name: Build Android (AGP 9 built-in Kotlin)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: "21"
+
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+
+      - name: Switch the example to AGP's built-in Kotlin
+        run: |
+          sed -i 's/^android.builtInKotlin=false$/android.builtInKotlin=true/' example/android/gradle.properties
+          grep -q '^android.builtInKotlin=true$' example/android/gradle.properties
+
+      - name: Build Android example (built-in Kotlin)
         run: flutter build apk --debug
         working-directory: example
 
@@ -96,6 +142,8 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    env:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     steps:
       - uses: actions/checkout@v4
 
@@ -121,6 +169,11 @@ jobs:
           fi
 
       - name: Upload coverage to Codecov
+        # Dependabot-triggered runs don't receive repository secrets, and a
+        # tokenless upload to a protected branch fails hard — skip the upload
+        # there instead of failing the whole job (coverage is still enforced
+        # by the step above).
+        if: env.CODECOV_TOKEN != ''
         uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -32,4 +32,4 @@ jobs:
       id-token: write
     # Uses the reusable publish workflow provided by dart-lang/setup-dart.
     # This handles OIDC token exchange and runs `dart pub publish --force`.
-    uses: dart-lang/setup-dart/.github/workflows/publish.yml@v1.7.2
+    uses: dart-lang/setup-dart/.github/workflows/publish.yml@v1.8.0

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id "com.android.application"
-    id "org.jetbrains.kotlin.android"
+    // Kotlin support comes from the Flutter tool: AGP's built-in Kotlin when
+    // android.builtInKotlin=true, an auto-applied KGP otherwise (#120).
     id "dev.flutter.flutter-gradle-plugin"
 }
 
@@ -10,11 +11,6 @@ if (localPropertiesFile.exists()) {
     localPropertiesFile.withReader('UTF-8') { reader ->
         localProperties.load(reader)
     }
-}
-
-def flutterRoot = localProperties.getProperty('flutter.sdk')
-if (flutterRoot == null) {
-    throw new GradleException("Flutter SDK not found. Define location with flutter.sdk in the local.properties file.")
 }
 
 def flutterVersionCode = localProperties.getProperty('flutter.versionCode')
@@ -28,46 +24,44 @@ if (flutterVersionName == null) {
 }
 
 android {
-    namespace "com.flutterplaza.no_screenshot_example"
-    compileSdkVersion flutter.compileSdkVersion
-    ndkVersion flutter.ndkVersion
+    namespace = "com.flutterplaza.no_screenshot_example"
+    compileSdk = flutter.compileSdkVersion
+    ndkVersion = flutter.ndkVersion
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
-    }
-
-    kotlinOptions {
-        jvmTarget = '1.8'
-    }
-
-    sourceSets {
-        main.java.srcDirs += 'src/main/kotlin'
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
 
     defaultConfig {
-        applicationId "com.flutterplaza.no_screenshot_example"
+        applicationId = "com.flutterplaza.no_screenshot_example"
         // You can update the following values to match your application needs.
         // For more information, see: https://docs.flutter.dev/deployment/android#reviewing-the-build-configuration.
-        minSdkVersion flutter.minSdkVersion
-        targetSdkVersion flutter.targetSdkVersion
-        versionCode flutterVersionCode.toInteger()
-        versionName flutterVersionName
+        minSdk = flutter.minSdkVersion
+        targetSdk = flutter.targetSdkVersion
+        versionCode = flutterVersionCode.toInteger()
+        versionName = flutterVersionName
     }
 
     buildTypes {
         release {
             // TODO: Add your own signing config for the release build.
             // Signing with the debug keys for now, so `flutter run --release` works.
-            signingConfig signingConfigs.debug
+            signingConfig = signingConfigs.debug
         }
     }
 }
 
 flutter {
-    source '../..'
+    source = '../..'
 }
 
-dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+// Works on both Kotlin paths: the classic KGP (auto-applied by the Flutter
+// tool when android.builtInKotlin=false) does NOT align its jvmTarget with
+// compileOptions, so without this the Kotlin/Java jvm-target consistency
+// check fails; AGP's built-in Kotlin accepts the same block.
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
+    }
 }

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -1,11 +1,3 @@
-buildscript {
-    ext.kotlin_version = '2.1.0'
-    repositories {
-        google()
-        mavenCentral()
-    }
-}
-
 allprojects {
     repositories {
         google()
@@ -13,14 +5,17 @@ allprojects {
     }
 }
 
-rootProject.buildDir = '../build'
+// Gradle 9 removed Project.buildDir; relocate the build directory through
+// the layout API instead (matches the current Flutter app template).
+def newBuildDir = rootProject.layout.buildDirectory.dir("../../build").get()
+rootProject.layout.buildDirectory.value(newBuildDir)
 subprojects {
-    project.buildDir = "${rootProject.buildDir}/${project.name}"
+    project.layout.buildDirectory.value(newBuildDir.dir(project.name))
 }
 subprojects {
     project.evaluationDependsOn(':app')
 }
 
 tasks.register("clean", Delete) {
-    delete rootProject.buildDir
+    delete rootProject.layout.buildDirectory
 }

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -1,3 +1,8 @@
 org.gradle.jvmargs=-Xmx4096M
 android.useAndroidX=true
-android.enableJetifier=true
+# Flutter currently defaults AGP 9 projects to the legacy Kotlin Gradle
+# Plugin path while the plugin ecosystem migrates (flutter/flutter#183910).
+# Declared explicitly (instead of letting the tool inject them) so the
+# built-in Kotlin CI lane can flip builtInKotlin to true (#129).
+android.newDsl=false
+android.builtInKotlin=false

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-all.zip

--- a/example/android/settings.gradle
+++ b/example/android/settings.gradle
@@ -18,8 +18,11 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.6.0" apply false
-    id "org.jetbrains.kotlin.android" version "2.1.0" apply false
+    id "com.android.application" version "9.1.0" apply false
+    // Declaration only (apply false): the app module no longer applies KGP.
+    // On the default legacy path (android.builtInKotlin=false) the Flutter
+    // tool applies it from here; the built-in Kotlin CI lane ignores it.
+    id "org.jetbrains.kotlin.android" version "2.4.0" apply false
 }
 
 include ":app"

--- a/example/windows/CMakeLists.txt
+++ b/example/windows/CMakeLists.txt
@@ -52,6 +52,12 @@ add_subdirectory(${FLUTTER_MANAGED_DIR})
 # Application build; see runner/CMakeLists.txt.
 add_subdirectory("runner")
 
+# === Tests ===
+# Build the no_screenshot plugin's native unit tests as part of the example
+# (#128). The aggregate `unit_tests` target follows the flutter/packages
+# repo-tooling convention.
+set(include_no_screenshot_tests TRUE)
+add_custom_target(unit_tests DEPENDS no_screenshot_test)
 
 # Generated plugin build rules, which manage building the plugins and adding
 # them to the application.

--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -11,6 +11,7 @@ add_library(${PLUGIN_NAME} SHARED
   "screenshot_detection.cpp"
   "recording_detection.cpp"
   "state_persistence.cpp"
+  "window_affinity.cpp"
 )
 
 apply_standard_settings(${PLUGIN_NAME})
@@ -25,3 +26,38 @@ target_include_directories(${PLUGIN_NAME} INTERFACE
 
 target_link_libraries(${PLUGIN_NAME} PRIVATE flutter flutter_wrapper_plugin)
 target_link_libraries(${PLUGIN_NAME} PRIVATE shlwapi)
+
+# === Tests ===
+# Built when the example app sets include_no_screenshot_tests (see
+# example/windows/CMakeLists.txt), following the flutter/packages pattern.
+
+if (${include_${PROJECT_NAME}_tests})
+set(TEST_RUNNER "${PROJECT_NAME}_test")
+enable_testing()
+include(FetchContent)
+FetchContent_Declare(
+  googletest
+  URL https://github.com/google/googletest/archive/v1.15.2.zip
+)
+# Prevent overriding the parent project's compiler/linker settings
+set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+# Disable install commands for gtest so it doesn't end up in the bundle.
+set(INSTALL_GTEST OFF CACHE BOOL "Disable installation of googletest" FORCE)
+
+FetchContent_MakeAvailable(googletest)
+
+# The display-affinity logic under test (#119/#128) is pure Win32, so the
+# sources are compiled directly into the test binary — no Flutter engine or
+# wrapper dependency is needed.
+add_executable(${TEST_RUNNER}
+  test/no_screenshot_windows_test.cpp
+  window_affinity.cpp
+  screenshot_prevention.cpp
+)
+apply_standard_settings(${TEST_RUNNER})
+target_include_directories(${TEST_RUNNER} PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}")
+target_link_libraries(${TEST_RUNNER} PRIVATE gtest_main)
+
+include(GoogleTest)
+gtest_discover_tests(${TEST_RUNNER})
+endif()

--- a/windows/no_screenshot_plugin.cpp
+++ b/windows/no_screenshot_plugin.cpp
@@ -89,16 +89,11 @@ NoScreenshotPlugin::NoScreenshotPlugin(
   window_proc_delegate_id_ = registrar_->RegisterTopLevelWindowProcDelegate(
       [this](HWND hwnd, UINT message, WPARAM wparam,
              LPARAM lparam) -> std::optional<LRESULT> {
-        // Adopt only the window that actually hosts our view — an embedder
-        // may forward several top-level windows' messages into one engine,
-        // and migrating to a foreign window would thrash the affinity.
-        if (prevent_screenshot_ && applied_hwnd_ != hwnd &&
-            hwnd == GetFlutterWindowHandle()) {
-          if (applied_hwnd_ != nullptr && ::IsWindow(applied_hwnd_)) {
-            PreventionDeactivate(applied_hwnd_);
-          }
-          PreventionActivate(hwnd);
-          applied_hwnd_ = hwnd;
+        // Cheap pre-check first: the delegate runs for every window message,
+        // so only resolve the view's root when a migration is possible.
+        // MaybeMigrate adopts only the window that actually hosts our view.
+        if (prevent_screenshot_ && affinity_.applied_window() != hwnd) {
+          affinity_.MaybeMigrate(hwnd, GetFlutterWindowHandle());
         }
         return std::nullopt;
       });
@@ -142,16 +137,9 @@ NoScreenshotPlugin::~NoScreenshotPlugin() {
 HWND NoScreenshotPlugin::GetFlutterWindowHandle() {
   if (registrar_ == nullptr) return nullptr;
   auto* view = registrar_->GetView();
-  HWND view_hwnd = view ? view->GetNativeWindow() : nullptr;
-  if (view_hwnd == nullptr) return nullptr;
-  // SetWindowDisplayAffinity only takes effect on top-level windows, and the
-  // Flutter view is a child window that the runner reparents via SetParent —
-  // affinity set on the view itself silently protects nothing (#119). Resolve
-  // the root ancestor on every call, never cached: the parent chain changes
-  // when the runner attaches the view after plugin registration. For a view
-  // that is itself top-level, GA_ROOT returns the view unchanged.
-  HWND root = ::GetAncestor(view_hwnd, GA_ROOT);
-  return root ? root : view_hwnd;
+  // Affinity set on the child view itself silently protects nothing (#119) —
+  // resolve the top-level ancestor per call; see ResolveRootWindow.
+  return ResolveRootWindow(view ? view->GetNativeWindow() : nullptr);
 }
 
 // ---------------------------------------------------------------------------
@@ -171,31 +159,7 @@ bool NoScreenshotPlugin::OverlayClaim() const {
 void NoScreenshotPlugin::ApplyEffectivePrevention() {
   const bool effective = independent_prevention_ || OverlayClaim();
   prevent_screenshot_ = effective;
-  HWND hwnd = GetFlutterWindowHandle();
-  if (hwnd == nullptr) {
-    // View not resolvable (headless engine or teardown). Releasing
-    // prevention must still clear a previously protected window; an active
-    // claim keeps that window protected (fail-secure).
-    if (!effective && applied_hwnd_ != nullptr && ::IsWindow(applied_hwnd_)) {
-      PreventionDeactivate(applied_hwnd_);
-      applied_hwnd_ = nullptr;
-    }
-    return;
-  }
-  // If a previous apply targeted a different window (the view resolved
-  // before the runner reparented it), clear that one first so no window is
-  // left holding a stale affinity.
-  if (applied_hwnd_ != nullptr && applied_hwnd_ != hwnd &&
-      ::IsWindow(applied_hwnd_)) {
-    PreventionDeactivate(applied_hwnd_);
-  }
-  if (effective) {
-    PreventionActivate(hwnd);
-    applied_hwnd_ = hwnd;
-  } else {
-    PreventionDeactivate(hwnd);
-    applied_hwnd_ = nullptr;
-  }
+  affinity_.ApplyEffective(effective, GetFlutterWindowHandle());
 }
 
 void NoScreenshotPlugin::HandleMethodCall(

--- a/windows/no_screenshot_plugin.h
+++ b/windows/no_screenshot_plugin.h
@@ -15,6 +15,7 @@
 #include "recording_detection.h"
 #include "screenshot_detection.h"
 #include "state_persistence.h"
+#include "window_affinity.h"
 
 namespace no_screenshot {
 
@@ -77,10 +78,8 @@ class NoScreenshotPlugin : public flutter::Plugin {
   bool has_pending_event_ = false;
   UINT_PTR stream_timer_id_ = 0;
 
-  // Window the display affinity is currently applied to. Tracked so
-  // deactivation always targets the window that was actually protected,
-  // even if the view has been reparented since (#119).
-  HWND applied_hwnd_ = nullptr;
+  // Tracks which window the display affinity is applied to (#119).
+  AffinityTracker affinity_;
   int window_proc_delegate_id_ = -1;
 
   // P8 metadata

--- a/windows/test/no_screenshot_windows_test.cpp
+++ b/windows/test/no_screenshot_windows_test.cpp
@@ -1,0 +1,351 @@
+#include <windows.h>
+
+#include <gtest/gtest.h>
+
+#include <vector>
+
+#include "screenshot_prevention.h"
+#include "window_affinity.h"
+
+// Available on Windows 10 2004+ (build 19041+); mirror of the guard in
+// screenshot_prevention.cpp for SDKs that predate it.
+#ifndef WDA_EXCLUDEFROMCAPTURE
+#define WDA_EXCLUDEFROMCAPTURE 0x00000011
+#endif
+
+namespace no_screenshot {
+namespace {
+
+constexpr wchar_t kTestClassName[] = L"NoScreenshotAffinityTestWindow";
+
+void RegisterTestClass() {
+  static bool registered = false;
+  if (registered) return;
+  WNDCLASSW wc = {};
+  wc.lpfnWndProc = DefWindowProcW;
+  wc.hInstance = GetModuleHandleW(nullptr);
+  wc.lpszClassName = kTestClassName;
+  RegisterClassW(&wc);
+  registered = true;
+}
+
+DWORD AffinityOf(HWND hwnd) {
+  DWORD affinity = WDA_NONE;
+  GetWindowDisplayAffinity(hwnd, &affinity);
+  return affinity;
+}
+
+// SetWindowDisplayAffinity requires DWM composition and an interactive
+// session, which may be missing in exotic environments (Server Core,
+// session 0). Probe once; assertions on the actual affinity value are gated
+// on this so bookkeeping coverage still runs everywhere. GitHub-hosted
+// Windows runners have a composited desktop, so the probe passes there and
+// affinity values are asserted for real.
+DWORD g_probe_error = ERROR_SUCCESS;
+
+bool CanSetAffinity() {
+  static int cached = -1;
+  if (cached == -1) {
+    RegisterTestClass();
+    HWND probe = CreateWindowExW(0, kTestClassName, L"probe",
+                                 WS_OVERLAPPEDWINDOW, CW_USEDEFAULT,
+                                 CW_USEDEFAULT, 100, 100, nullptr, nullptr,
+                                 GetModuleHandleW(nullptr), nullptr);
+    if (probe != nullptr) {
+      ShowWindow(probe, SW_SHOWNOACTIVATE);
+    }
+    if (probe != nullptr &&
+        (SetWindowDisplayAffinity(probe, WDA_EXCLUDEFROMCAPTURE) ||
+         SetWindowDisplayAffinity(probe, WDA_MONITOR))) {
+      cached = 1;
+    } else {
+      cached = 0;
+      g_probe_error = GetLastError();
+    }
+    if (probe != nullptr) {
+      SetWindowDisplayAffinity(probe, WDA_NONE);
+      DestroyWindow(probe);
+    }
+  }
+  return cached == 1;
+}
+
+// Scope note: these tests pin the extracted #119 logic (ResolveRootWindow +
+// AffinityTracker) against real Win32 windows. The plugin's thin glue —
+// GetFlutterWindowHandle() feeding the tracker and the WindowProc delegate
+// invoking MaybeMigrate — has no Flutter-free test seam (it needs a live
+// PluginRegistrarWindows) and remains review-guarded; keep those call sites
+// trivial.
+//
+// Creates real windows and destroys them on teardown. Top-level windows are
+// shown without activation (DWM only composes shown windows, and affinity
+// values are asserted for real when the environment supports it); child
+// windows stay hidden.
+class WindowAffinityTest : public ::testing::Test {
+ protected:
+  HWND MakeTopLevel() {
+    RegisterTestClass();
+    HWND hwnd = CreateWindowExW(0, kTestClassName, L"top",
+                                WS_OVERLAPPEDWINDOW, CW_USEDEFAULT,
+                                CW_USEDEFAULT, 200, 200, nullptr, nullptr,
+                                GetModuleHandleW(nullptr), nullptr);
+    EXPECT_NE(hwnd, nullptr);
+    // Shown (without focus) because display affinity is only meaningfully
+    // asserted against a window DWM actually composes.
+    ShowWindow(hwnd, SW_SHOWNOACTIVATE);
+    windows_.push_back(hwnd);
+    return hwnd;
+  }
+
+  HWND MakeChild(HWND parent) {
+    RegisterTestClass();
+    HWND hwnd = CreateWindowExW(0, kTestClassName, L"child", WS_CHILD, 0, 0,
+                                100, 100, parent, nullptr,
+                                GetModuleHandleW(nullptr), nullptr);
+    EXPECT_NE(hwnd, nullptr);
+    windows_.push_back(hwnd);
+    return hwnd;
+  }
+
+  void TearDown() override {
+    // Reverse order so children go before their parents.
+    for (auto it = windows_.rbegin(); it != windows_.rend(); ++it) {
+      if (::IsWindow(*it)) {
+        DestroyWindow(*it);
+      }
+    }
+    windows_.clear();
+  }
+
+  std::vector<HWND> windows_;
+};
+
+// --- Environment -----------------------------------------------------------
+
+// Witnesses in the CI log whether affinity values are asserted for real or
+// the suite fell back to bookkeeping-only coverage (#128).
+TEST_F(WindowAffinityTest, EnvironmentSupportsSettingDisplayAffinity) {
+  if (!CanSetAffinity()) {
+    GTEST_SKIP() << "SetWindowDisplayAffinity unavailable (GetLastError="
+                 << g_probe_error
+                 << "); affinity-value assertions are skipped in this "
+                    "environment, bookkeeping assertions still run.";
+  }
+  SUCCEED();
+}
+
+// --- ResolveRootWindow -----------------------------------------------------
+
+TEST_F(WindowAffinityTest, ResolveRootNullYieldsNull) {
+  EXPECT_EQ(ResolveRootWindow(nullptr), nullptr);
+}
+
+TEST_F(WindowAffinityTest, ResolveRootTopLevelResolvesToItself) {
+  HWND top = MakeTopLevel();
+  EXPECT_EQ(ResolveRootWindow(top), top);
+}
+
+TEST_F(WindowAffinityTest, ResolveRootChildResolvesToTopLevelParent) {
+  HWND top = MakeTopLevel();
+  HWND child = MakeChild(top);
+  EXPECT_EQ(ResolveRootWindow(child), top);
+}
+
+TEST_F(WindowAffinityTest, ResolveRootGrandchildResolvesToRoot) {
+  HWND top = MakeTopLevel();
+  HWND child = MakeChild(top);
+  HWND grandchild = MakeChild(child);
+  EXPECT_EQ(ResolveRootWindow(grandchild), top);
+}
+
+// The #119 startup sequence: the runner calls SetParent on the view AFTER
+// plugin registration, so root resolution must track the live parent chain
+// instead of caching the first answer.
+TEST_F(WindowAffinityTest, ResolveRootTracksReparenting) {
+  HWND top_a = MakeTopLevel();
+  HWND top_b = MakeTopLevel();
+  HWND child = MakeChild(top_a);
+  ASSERT_EQ(ResolveRootWindow(child), top_a);
+  SetParent(child, top_b);
+  EXPECT_EQ(ResolveRootWindow(child), top_b);
+}
+
+// --- PreventionActivate / PreventionDeactivate -----------------------------
+
+TEST_F(WindowAffinityTest, PreventionActivateSetsCaptureExclusion) {
+  if (!CanSetAffinity()) {
+    GTEST_SKIP() << "SetWindowDisplayAffinity unavailable (no DWM?)";
+  }
+  HWND top = MakeTopLevel();
+  PreventionActivate(top);
+  EXPECT_NE(AffinityOf(top), static_cast<DWORD>(WDA_NONE));
+  PreventionDeactivate(top);
+  EXPECT_EQ(AffinityOf(top), static_cast<DWORD>(WDA_NONE));
+}
+
+// --- AffinityTracker::ApplyEffective ---------------------------------------
+
+TEST_F(WindowAffinityTest, ApplyEffectiveActivateTracksAppliedWindow) {
+  HWND top = MakeTopLevel();
+  AffinityTracker tracker;
+  tracker.ApplyEffective(true, top);
+  EXPECT_EQ(tracker.applied_window(), top);
+  if (CanSetAffinity()) {
+    EXPECT_NE(AffinityOf(top), static_cast<DWORD>(WDA_NONE));
+  }
+}
+
+TEST_F(WindowAffinityTest, ApplyEffectiveDeactivateClearsAppliedWindow) {
+  HWND top = MakeTopLevel();
+  AffinityTracker tracker;
+  tracker.ApplyEffective(true, top);
+  tracker.ApplyEffective(false, top);
+  EXPECT_EQ(tracker.applied_window(), nullptr);
+  if (CanSetAffinity()) {
+    EXPECT_EQ(AffinityOf(top), static_cast<DWORD>(WDA_NONE));
+  }
+}
+
+// When the resolved root changes (the runner reparented the view), the old
+// window must not be left holding a stale affinity.
+TEST_F(WindowAffinityTest, ApplyEffectiveMigratesOffPreviousWindow) {
+  HWND top_a = MakeTopLevel();
+  HWND top_b = MakeTopLevel();
+  AffinityTracker tracker;
+  tracker.ApplyEffective(true, top_a);
+  tracker.ApplyEffective(true, top_b);
+  EXPECT_EQ(tracker.applied_window(), top_b);
+  if (CanSetAffinity()) {
+    EXPECT_EQ(AffinityOf(top_a), static_cast<DWORD>(WDA_NONE));
+    EXPECT_NE(AffinityOf(top_b), static_cast<DWORD>(WDA_NONE));
+  }
+}
+
+// Fail-secure: an unresolvable view (headless, teardown) must not drop
+// protection a still-active claim demands.
+TEST_F(WindowAffinityTest, ApplyEffectiveNullRootKeepsProtectionWhileClaimed) {
+  HWND top = MakeTopLevel();
+  AffinityTracker tracker;
+  tracker.ApplyEffective(true, top);
+  tracker.ApplyEffective(true, nullptr);
+  EXPECT_EQ(tracker.applied_window(), top);
+  if (CanSetAffinity()) {
+    EXPECT_NE(AffinityOf(top), static_cast<DWORD>(WDA_NONE));
+  }
+}
+
+// ...but releasing with an unresolvable view must still clear the window
+// that was protected.
+TEST_F(WindowAffinityTest, ApplyEffectiveNullRootReleaseClearsPrevious) {
+  HWND top = MakeTopLevel();
+  AffinityTracker tracker;
+  tracker.ApplyEffective(true, top);
+  tracker.ApplyEffective(false, nullptr);
+  EXPECT_EQ(tracker.applied_window(), nullptr);
+  if (CanSetAffinity()) {
+    EXPECT_EQ(AffinityOf(top), static_cast<DWORD>(WDA_NONE));
+  }
+}
+
+TEST_F(WindowAffinityTest, ApplyEffectiveReleaseWithoutPriorApplyIsNoOp) {
+  AffinityTracker tracker;
+  tracker.ApplyEffective(false, nullptr);
+  EXPECT_EQ(tracker.applied_window(), nullptr);
+}
+
+TEST_F(WindowAffinityTest, ApplyEffectiveSkipsDestroyedPreviousWindow) {
+  HWND top_a = MakeTopLevel();
+  HWND top_b = MakeTopLevel();
+  AffinityTracker tracker;
+  tracker.ApplyEffective(true, top_a);
+  DestroyWindow(top_a);
+  tracker.ApplyEffective(true, top_b);
+  EXPECT_EQ(tracker.applied_window(), top_b);
+}
+
+// --- AffinityTracker::MaybeMigrate (top-level WindowProc delegate, #119) ---
+
+// Persisted prevention restored before the runner attached the view: nothing
+// applied yet, then the delegate reports the real top-level window.
+TEST_F(WindowAffinityTest, MaybeMigrateAdoptsRootWhenNothingApplied) {
+  HWND top = MakeTopLevel();
+  AffinityTracker tracker;
+  EXPECT_TRUE(tracker.MaybeMigrate(top, top));
+  EXPECT_EQ(tracker.applied_window(), top);
+  if (CanSetAffinity()) {
+    EXPECT_NE(AffinityOf(top), static_cast<DWORD>(WDA_NONE));
+  }
+}
+
+// Prevention was applied to the wrong window (the pre-reparent root); the
+// delegate migrates it to the window that actually hosts the view.
+TEST_F(WindowAffinityTest, MaybeMigrateMovesAffinityToCurrentRoot) {
+  HWND old_root = MakeTopLevel();
+  HWND new_root = MakeTopLevel();
+  AffinityTracker tracker;
+  tracker.ApplyEffective(true, old_root);
+  EXPECT_TRUE(tracker.MaybeMigrate(new_root, new_root));
+  EXPECT_EQ(tracker.applied_window(), new_root);
+  if (CanSetAffinity()) {
+    EXPECT_EQ(AffinityOf(old_root), static_cast<DWORD>(WDA_NONE));
+    EXPECT_NE(AffinityOf(new_root), static_cast<DWORD>(WDA_NONE));
+  }
+}
+
+// An embedder may forward several top-level windows' messages into one
+// engine; a delegate window that is not the view's root must not be adopted.
+TEST_F(WindowAffinityTest, MaybeMigrateRejectsForeignWindow) {
+  HWND root = MakeTopLevel();
+  HWND foreign = MakeTopLevel();
+  AffinityTracker tracker;
+  tracker.ApplyEffective(true, root);
+  EXPECT_FALSE(tracker.MaybeMigrate(foreign, root));
+  EXPECT_EQ(tracker.applied_window(), root);
+  if (CanSetAffinity()) {
+    EXPECT_EQ(AffinityOf(foreign), static_cast<DWORD>(WDA_NONE));
+  }
+}
+
+TEST_F(WindowAffinityTest, MaybeMigrateAlreadyAppliedIsNoOp) {
+  HWND root = MakeTopLevel();
+  AffinityTracker tracker;
+  tracker.ApplyEffective(true, root);
+  EXPECT_FALSE(tracker.MaybeMigrate(root, root));
+  EXPECT_EQ(tracker.applied_window(), root);
+}
+
+TEST_F(WindowAffinityTest, MaybeMigrateIgnoresNullDelegate) {
+  AffinityTracker tracker;
+  EXPECT_FALSE(tracker.MaybeMigrate(nullptr, nullptr));
+  EXPECT_EQ(tracker.applied_window(), nullptr);
+}
+
+// End-to-end shape of the #119 fix: apply lands on the pre-reparent root,
+// the runner reparents the view, and the delegate migrates the affinity to
+// the real top-level window.
+TEST_F(WindowAffinityTest, ReparentThenDelegateMigrationEndToEnd) {
+  HWND real_top = MakeTopLevel();
+  HWND view = MakeTopLevel();  // The view starts unparented (top-level).
+  AffinityTracker tracker;
+  tracker.ApplyEffective(true, ResolveRootWindow(view));
+  EXPECT_EQ(tracker.applied_window(), view);
+
+  // Runner attaches the view (SetChildContent -> SetParent).
+  SetWindowLongPtrW(view, GWL_STYLE,
+                    (GetWindowLongPtrW(view, GWL_STYLE) & ~WS_POPUP) |
+                        WS_CHILD);
+  SetParent(view, real_top);
+
+  // First delegate callback for the hosting top-level window.
+  HWND current_root = ResolveRootWindow(view);
+  ASSERT_EQ(current_root, real_top);
+  EXPECT_TRUE(tracker.MaybeMigrate(real_top, current_root));
+  EXPECT_EQ(tracker.applied_window(), real_top);
+  if (CanSetAffinity()) {
+    EXPECT_EQ(AffinityOf(view), static_cast<DWORD>(WDA_NONE));
+    EXPECT_NE(AffinityOf(real_top), static_cast<DWORD>(WDA_NONE));
+  }
+}
+
+}  // namespace
+}  // namespace no_screenshot

--- a/windows/window_affinity.cpp
+++ b/windows/window_affinity.cpp
@@ -1,0 +1,53 @@
+#include "window_affinity.h"
+
+#include "screenshot_prevention.h"
+
+namespace no_screenshot {
+
+HWND ResolveRootWindow(HWND view_hwnd) {
+  if (view_hwnd == nullptr) return nullptr;
+  HWND root = ::GetAncestor(view_hwnd, GA_ROOT);
+  return root ? root : view_hwnd;
+}
+
+void AffinityTracker::ApplyEffective(bool effective, HWND root) {
+  if (root == nullptr) {
+    // View not resolvable (headless engine or teardown). Releasing
+    // prevention must still clear a previously protected window; an active
+    // claim keeps that window protected (fail-secure).
+    if (!effective && applied_hwnd_ != nullptr && ::IsWindow(applied_hwnd_)) {
+      PreventionDeactivate(applied_hwnd_);
+      applied_hwnd_ = nullptr;
+    }
+    return;
+  }
+  // If a previous apply targeted a different window (the view resolved
+  // before the runner reparented it), clear that one first so no window is
+  // left holding a stale affinity.
+  if (applied_hwnd_ != nullptr && applied_hwnd_ != root &&
+      ::IsWindow(applied_hwnd_)) {
+    PreventionDeactivate(applied_hwnd_);
+  }
+  if (effective) {
+    PreventionActivate(root);
+    applied_hwnd_ = root;
+  } else {
+    PreventionDeactivate(root);
+    applied_hwnd_ = nullptr;
+  }
+}
+
+bool AffinityTracker::MaybeMigrate(HWND delegate_hwnd, HWND current_root) {
+  if (delegate_hwnd == nullptr || delegate_hwnd == applied_hwnd_ ||
+      delegate_hwnd != current_root) {
+    return false;
+  }
+  if (applied_hwnd_ != nullptr && ::IsWindow(applied_hwnd_)) {
+    PreventionDeactivate(applied_hwnd_);
+  }
+  PreventionActivate(delegate_hwnd);
+  applied_hwnd_ = delegate_hwnd;
+  return true;
+}
+
+}  // namespace no_screenshot

--- a/windows/window_affinity.h
+++ b/windows/window_affinity.h
@@ -1,0 +1,49 @@
+#ifndef NO_SCREENSHOT_WINDOW_AFFINITY_H_
+#define NO_SCREENSHOT_WINDOW_AFFINITY_H_
+
+#include <windows.h>
+
+namespace no_screenshot {
+
+// Resolves the top-level ancestor that display affinity must target for a
+// (possibly reparented) Flutter view window. SetWindowDisplayAffinity only
+// takes effect on top-level windows, and the standard runner reparents the
+// Flutter view via SetParent after plugin registration (#119), so the root
+// must be resolved per call, never cached. For a window that is itself
+// top-level, returns the window unchanged; returns nullptr for nullptr.
+HWND ResolveRootWindow(HWND view_hwnd);
+
+// Tracks which top-level window currently holds the display affinity and
+// keeps it consistent as the effective prevention claim and the view's
+// parent chain change. Pure Win32 — no Flutter dependencies — so the #119
+// regression surface is unit-testable against synthetic windows.
+class AffinityTracker {
+ public:
+  // Applies (or clears) prevention on `root` — the current top-level window,
+  // or nullptr when the view is not resolvable (headless engine, teardown).
+  // Migrates the affinity off a previously protected window so no window is
+  // left holding a stale affinity. With a null root this is fail-secure: an
+  // active claim keeps the previously protected window protected, while
+  // releasing still clears it.
+  void ApplyEffective(bool effective, HWND root);
+
+  // Delegate-driven migration (#119): adopt `delegate_hwnd` iff prevention
+  // is currently applied elsewhere (or nowhere) and `delegate_hwnd` is the
+  // window that actually hosts the view (`current_root`) — an embedder may
+  // forward several top-level windows' messages into one engine, and
+  // migrating to a foreign window would thrash the affinity. Returns true
+  // if the affinity moved.
+  bool MaybeMigrate(HWND delegate_hwnd, HWND current_root);
+
+  // Window the display affinity is currently applied to, if any. Tracked so
+  // deactivation always targets the window that was actually protected,
+  // even if the view has been reparented since (#119).
+  HWND applied_window() const { return applied_hwnd_; }
+
+ private:
+  HWND applied_hwnd_ = nullptr;
+};
+
+}  // namespace no_screenshot
+
+#endif  // NO_SCREENSHOT_WINDOW_AFFINITY_H_


### PR DESCRIPTION
Addresses every open issue and PR in one branch: native Windows test coverage (#128), AGP 9 built-in Kotlin CI coverage (#129), and the three dependabot action bumps (#130, #132, #134) — plus two CI breakages discovered along the way.

## Windows native regression coverage (fixes #128)

The pure-Win32 #119 logic is extracted from `NoScreenshotPlugin` into `windows/window_affinity.{h,cpp}` (`ResolveRootWindow` + `AffinityTracker`) — a behavior-preserving move (the only divergence: a null delegate HWND is now rejected instead of dropping protection, which is unreachable in practice and fail-secure). A googletest suite (`windows/test/no_screenshot_windows_test.cpp`, wired via the flutter/packages CMake pattern with googletest 1.15.2) pins it against real synthetic windows:

- root resolution for top-level / child / grandchild windows, including live reparenting (`SetParent` after registration — the #119 startup sequence);
- applied-window bookkeeping: migration off a stale window, fail-secure null-root handling both ways, destroyed-window guards;
- the delegate migration guard: adopt-when-nothing-applied (persisted restore), migrate-to-real-root, foreign-window rejection;
- an end-to-end #119 sequence (apply to pre-reparent root → reparent → delegate migration).

Affinity values are asserted for real where DWM composition exists — research indicates GitHub-hosted Windows runners qualify (interactive composited session); an environment-witness test logs this in CI. Elsewhere the suite degrades to bookkeeping-only assertions instead of failing. The Build Windows job builds and runs the suite.

Known limitation (noted in the test file): the plugin's ~3 lines of glue wiring the tracker have no Flutter-free test seam and remain review-guarded; full plugin-level tests would need a mocked `PluginRegistrarWindows`. The `desktop_multi_window` secondary-window path still deserves the manual on-device pass noted in #128.

## Android: unbreak CI and cover AGP 9 built-in Kotlin (fixes #129)

**Flutter 3.47 went stable on 2026-08-12 and its Gradle plugin now hard-errors on Gradle < 8.14** — the example (AGP 8.6.0 / Gradle 8.7) stopped building, so `Build Android` is currently red on `development` (see #134's checks). The example is migrated to the Flutter 3.47 template shape: AGP **9.1.0**, Gradle **9.3.1**, Kotlin **2.4.0** declared but no longer applied by the app module, Java 17 (with the template's top-level `kotlin { compilerOptions }` block — classic KGP doesn't align `jvmTarget` with `compileOptions`), Gradle-9 `layout.buildDirectory` API, and explicit `android.builtInKotlin=false` / `android.newDsl=false` (Flutter's current AGP 9 default, flutter/flutter#183910).

CI coverage for #129 then comes in three layers:
- the default `Build Android` job now builds on **AGP 9.1.0 via the legacy auto-applied-KGP path** (Flutter's default);
- a new **`Build Android (AGP 9 built-in Kotlin)`** job flips `android.builtInKotlin=true` on every PR — the path the plugin's no-KGP build script (#120/#124) actually relies on;
- a weekly **Android Early Warning** workflow builds the built-in Kotlin lane against Flutter **beta** (non-blocking, `workflow_dispatch`-able).

Note: the example now effectively needs Flutter ≥ 3.47 to build (the plugin's published floor stays 3.44 — plugin code is untouched by the Android changes).

## CI fixes and action bumps (supersedes #130, #132; #134 → #136)

- **Codecov upload no longer fails dependabot PRs**: dependabot-triggered runs receive no repository secrets, so the tokenless upload to a protected branch failed hard (`Test` is red on #132/#134 for this reason, not because of tests). The upload step is now skipped when `CODECOV_TOKEN` is absent; the 75% coverage floor still gates the job.
- `actions/setup-java` v4 → **v5** (#132), `dart-lang/setup-dart` publish workflow 1.7.2 → **1.8.0** (#130, also clears the deprecated-Node-20 warning). Dependabot closes its PRs once the bumps land.
- The `claude-code-review.yaml` changes (claude-code-action → 1.0.191, dependabot skip) originally lived here but moved to **#136**: claude-code-action refuses to run on a PR that modifies its own workflow file, which would have disabled the bot review of this PR.

No Dart/plugin runtime code changes; no version bump. Windows changes are a behavior-preserving refactor verified for semantic equivalence path-by-path.

