### PR TITLE
ci: bump claude-code-action to v1.0.191 and skip dependabot PRs

### DIFF
--- a/.github/workflows/claude-code-review.yaml
+++ b/.github/workflows/claude-code-review.yaml
@@ -6,6 +6,9 @@ on:
 
 jobs:
   claude-review:
+    # Dependabot-triggered runs don't receive repository secrets, so the
+    # review can't authenticate there — and version bumps don't need it.
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -18,7 +21,7 @@ jobs:
           fetch-depth: 1
 
       - name: Run Claude Code Review
-        uses: anthropics/claude-code-action@v1.0.183
+        uses: anthropics/claude-code-action@v1.0.191
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |


### PR DESCRIPTION
Split out of #135, supersedes #134.

- `anthropics/claude-code-action` 1.0.183 → **1.0.191** (newer than #134's 1.0.190; verified released).
- The `claude-review` job now skips dependabot PRs: dependabot-triggered runs receive no repository secrets, so the job failed on every dependabot PR (see #132's checks).

These changes ship separately because claude-code-action refuses to run on any PR that modifies its own workflow file (the file must match the default branch's version — a guard against prompt/token hijacking via PR edits). Consequently the bot will also skip reviewing *this* PR — that's the expected behavior the action itself documents, and it takes effect once merged.